### PR TITLE
[iOS] TrackListView 구현

### DIFF
--- a/iOS/MiniVibe/MiniVibe.xcodeproj/project.pbxproj
+++ b/iOS/MiniVibe/MiniVibe.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		51386FCC256A8D9F006CDAA6 /* TrackListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51386FCB256A8D9F006CDAA6 /* TrackListViewModel.swift */; };
 		51386FD1256A8DE2006CDAA6 /* TrackCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51386FD0256A8DE2006CDAA6 /* TrackCell.swift */; };
 		51386FF3256AB14F006CDAA6 /* TrackListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51386FF2256AB14E006CDAA6 /* TrackListView.swift */; };
+		514E0B72256BDBF0009C6953 /* EllipsisAccessoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 514E0B71256BDBF0009C6953 /* EllipsisAccessoryView.swift */; };
+		514E0B7A256BDC0C009C6953 /* HeartAccessoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 514E0B79256BDC0C009C6953 /* HeartAccessoryView.swift */; };
 		CF05F8A82567E7AD008080D7 /* MiniVibeApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF05F8A72567E7AD008080D7 /* MiniVibeApp.swift */; };
 		CF05F8AA2567E7AD008080D7 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF05F8A92567E7AD008080D7 /* ContentView.swift */; };
 		CF05F8AC2567E7B0008080D7 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = CF05F8AB2567E7B0008080D7 /* Assets.xcassets */; };
@@ -43,6 +45,8 @@
 		51386FCB256A8D9F006CDAA6 /* TrackListViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrackListViewModel.swift; sourceTree = "<group>"; };
 		51386FD0256A8DE2006CDAA6 /* TrackCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrackCell.swift; sourceTree = "<group>"; };
 		51386FF2256AB14E006CDAA6 /* TrackListView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrackListView.swift; sourceTree = "<group>"; };
+		514E0B71256BDBF0009C6953 /* EllipsisAccessoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EllipsisAccessoryView.swift; sourceTree = "<group>"; };
+		514E0B79256BDC0C009C6953 /* HeartAccessoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeartAccessoryView.swift; sourceTree = "<group>"; };
 		CF05F8A42567E7AD008080D7 /* MiniVibe.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MiniVibe.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		CF05F8A72567E7AD008080D7 /* MiniVibeApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiniVibeApp.swift; sourceTree = "<group>"; };
 		CF05F8A92567E7AD008080D7 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -105,8 +109,18 @@
 			children = (
 				51386FD0256A8DE2006CDAA6 /* TrackCell.swift */,
 				51386FF2256AB14E006CDAA6 /* TrackListView.swift */,
+				514E0B70256BDB26009C6953 /* AccessoryViews */,
 			);
 			path = Views;
+			sourceTree = "<group>";
+		};
+		514E0B70256BDB26009C6953 /* AccessoryViews */ = {
+			isa = PBXGroup;
+			children = (
+				514E0B71256BDBF0009C6953 /* EllipsisAccessoryView.swift */,
+				514E0B79256BDC0C009C6953 /* HeartAccessoryView.swift */,
+			);
+			path = AccessoryViews;
 			sourceTree = "<group>";
 		};
 		CF05F89B2567E7AD008080D7 = {
@@ -307,8 +321,10 @@
 				51386FC4256A8D6F006CDAA6 /* Track.swift in Sources */,
 				CF05F8B12567E7B0008080D7 /* Persistence.swift in Sources */,
 				CF05F8AA2567E7AD008080D7 /* ContentView.swift in Sources */,
+				514E0B7A256BDC0C009C6953 /* HeartAccessoryView.swift in Sources */,
 				51386FCC256A8D9F006CDAA6 /* TrackListViewModel.swift in Sources */,
 				CF05F8A82567E7AD008080D7 /* MiniVibeApp.swift in Sources */,
+				514E0B72256BDBF0009C6953 /* EllipsisAccessoryView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iOS/MiniVibe/MiniVibe.xcodeproj/project.pbxproj
+++ b/iOS/MiniVibe/MiniVibe.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		51386FC4256A8D6F006CDAA6 /* Track.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51386FC3256A8D6F006CDAA6 /* Track.swift */; };
+		51386FCC256A8D9F006CDAA6 /* TrackListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51386FCB256A8D9F006CDAA6 /* TrackListViewModel.swift */; };
+		51386FD1256A8DE2006CDAA6 /* TrackCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51386FD0256A8DE2006CDAA6 /* TrackCell.swift */; };
+		51386FF3256AB14F006CDAA6 /* TrackListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51386FF2256AB14E006CDAA6 /* TrackListView.swift */; };
 		CF05F8A82567E7AD008080D7 /* MiniVibeApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF05F8A72567E7AD008080D7 /* MiniVibeApp.swift */; };
 		CF05F8AA2567E7AD008080D7 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF05F8A92567E7AD008080D7 /* ContentView.swift */; };
 		CF05F8AC2567E7B0008080D7 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = CF05F8AB2567E7B0008080D7 /* Assets.xcassets */; };
@@ -35,6 +39,10 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		51386FC3256A8D6F006CDAA6 /* Track.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Track.swift; sourceTree = "<group>"; };
+		51386FCB256A8D9F006CDAA6 /* TrackListViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrackListViewModel.swift; sourceTree = "<group>"; };
+		51386FD0256A8DE2006CDAA6 /* TrackCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrackCell.swift; sourceTree = "<group>"; };
+		51386FF2256AB14E006CDAA6 /* TrackListView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrackListView.swift; sourceTree = "<group>"; };
 		CF05F8A42567E7AD008080D7 /* MiniVibe.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MiniVibe.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		CF05F8A72567E7AD008080D7 /* MiniVibeApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiniVibeApp.swift; sourceTree = "<group>"; };
 		CF05F8A92567E7AD008080D7 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -76,6 +84,31 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		51386FC0256A8D3F006CDAA6 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				51386FC3256A8D6F006CDAA6 /* Track.swift */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
+		51386FC1256A8D45006CDAA6 /* ViewModels */ = {
+			isa = PBXGroup;
+			children = (
+				51386FCB256A8D9F006CDAA6 /* TrackListViewModel.swift */,
+			);
+			path = ViewModels;
+			sourceTree = "<group>";
+		};
+		51386FC2256A8D5B006CDAA6 /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				51386FD0256A8DE2006CDAA6 /* TrackCell.swift */,
+				51386FF2256AB14E006CDAA6 /* TrackListView.swift */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
 		CF05F89B2567E7AD008080D7 = {
 			isa = PBXGroup;
 			children = (
@@ -101,9 +134,12 @@
 			children = (
 				CF05F8A72567E7AD008080D7 /* MiniVibeApp.swift */,
 				CF05F8A92567E7AD008080D7 /* ContentView.swift */,
-				CF05F8AB2567E7B0008080D7 /* Assets.xcassets */,
-				CF05F8B02567E7B0008080D7 /* Persistence.swift */,
+				51386FC0256A8D3F006CDAA6 /* Models */,
+				51386FC1256A8D45006CDAA6 /* ViewModels */,
+				51386FC2256A8D5B006CDAA6 /* Views */,
 				CF05F8B52567E7B0008080D7 /* Info.plist */,
+				CF05F8B02567E7B0008080D7 /* Persistence.swift */,
+				CF05F8AB2567E7B0008080D7 /* Assets.xcassets */,
 				CF05F8B22567E7B0008080D7 /* MiniVibe.xcdatamodeld */,
 				CF05F8AD2567E7B0008080D7 /* Preview Content */,
 			);
@@ -265,9 +301,13 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				51386FD1256A8DE2006CDAA6 /* TrackCell.swift in Sources */,
 				CF05F8B42567E7B0008080D7 /* MiniVibe.xcdatamodeld in Sources */,
+				51386FF3256AB14F006CDAA6 /* TrackListView.swift in Sources */,
+				51386FC4256A8D6F006CDAA6 /* Track.swift in Sources */,
 				CF05F8B12567E7B0008080D7 /* Persistence.swift in Sources */,
 				CF05F8AA2567E7AD008080D7 /* ContentView.swift in Sources */,
+				51386FCC256A8D9F006CDAA6 /* TrackListViewModel.swift in Sources */,
 				CF05F8A82567E7AD008080D7 /* MiniVibeApp.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/iOS/MiniVibe/MiniVibe/Models/Track.swift
+++ b/iOS/MiniVibe/MiniVibe/Models/Track.swift
@@ -1,0 +1,15 @@
+//
+//  Track.swift
+//  MiniVibe
+//
+//  Created by 강병민 on 2020/11/22.
+//
+
+import Foundation
+
+struct Track: Identifiable {
+    let id: Int
+    let title: String
+    let artist: String
+    var isFavorite: Bool
+}

--- a/iOS/MiniVibe/MiniVibe/ViewModels/TrackListViewModel.swift
+++ b/iOS/MiniVibe/MiniVibe/ViewModels/TrackListViewModel.swift
@@ -1,0 +1,27 @@
+//
+//  TrackListViewModel.swift
+//  DemoTrackView
+//
+//  Created by 강병민 on 2020/11/22.
+//
+
+import Foundation
+
+class TrackListViewModel: ObservableObject {
+    @Published var tracks = [Track]()
+    
+    func fetchTracks() {
+        self.tracks = [Track(id: 1, title: "Dyanamite", artist: "방탄소년단", isFavorite: true),
+                       Track(id: 2, title: "Blooming", artist: "아이유", isFavorite: false),
+                       Track(id: 3, title: "Feel Good", artist: "프로미스나인", isFavorite: true),
+                       Track(id: 4, title: "Alone", artist: "Marshmello", isFavorite: false)
+        ]
+    }
+    
+    func toggleIsFavorite(for id: Int) {
+        if let index = tracks.firstIndex(where: { $0.id == id }) {
+            tracks[index].isFavorite.toggle()
+        }
+    }
+    
+}

--- a/iOS/MiniVibe/MiniVibe/Views/AccessoryViews/EllipsisAccessoryView.swift
+++ b/iOS/MiniVibe/MiniVibe/Views/AccessoryViews/EllipsisAccessoryView.swift
@@ -1,0 +1,32 @@
+//
+//  EllipsisAccessoryView.swift
+//  MiniVibe
+//
+//  Created by 강병민 on 2020/11/23.
+//
+
+import SwiftUI
+
+struct EllipsisAccessoryView: View {
+    var body: some View {
+        Button(action: {
+            print("show menu")
+            
+        }, label: {
+            Image(systemName: "ellipsis")
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(width: 20, height: 20, alignment: .center)
+                .accentColor(.gray)
+
+        })
+        .buttonStyle(BorderlessButtonStyle())
+    }
+}
+
+
+struct EllipsisAccessoryView_Previews: PreviewProvider {
+    static var previews: some View {
+        EllipsisAccessoryView()
+    }
+}

--- a/iOS/MiniVibe/MiniVibe/Views/AccessoryViews/HeartAccessoryView.swift
+++ b/iOS/MiniVibe/MiniVibe/Views/AccessoryViews/HeartAccessoryView.swift
@@ -1,0 +1,33 @@
+//
+//  HeartAccessoryView.swift
+//  MiniVibe
+//
+//  Created by 강병민 on 2020/11/23.
+//
+
+import SwiftUI
+
+struct HeartAccessoryView: View {
+    var isFavorite: Bool
+    let toggleFavorite: (() -> Void)?
+    
+    var body: some View {
+        Button(action: {
+            toggleFavorite?()
+        }, label: {
+            Image(systemName: isFavorite ? "heart.fill" : "heart")
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(width: 20, height: 20, alignment: .center)
+                .accentColor(.red)
+
+        })
+        .buttonStyle(BorderlessButtonStyle())
+    }
+}
+
+struct HeartAccessoryView_Previews: PreviewProvider {
+    static var previews: some View {
+        HeartAccessoryView(isFavorite: true, toggleFavorite: nil)
+    }
+}

--- a/iOS/MiniVibe/MiniVibe/Views/TrackCell.swift
+++ b/iOS/MiniVibe/MiniVibe/Views/TrackCell.swift
@@ -101,7 +101,7 @@ struct TrackInfo: View {
 }
 
  
-struct NewsView_Previews: PreviewProvider {
+struct TrackCell_Previews: PreviewProvider {
 
     static var previews: some View {
         let testTrack1 = Track(id: 1, title: "휘파람", artist: "BLACKPINK", isFavorite: true)

--- a/iOS/MiniVibe/MiniVibe/Views/TrackCell.swift
+++ b/iOS/MiniVibe/MiniVibe/Views/TrackCell.swift
@@ -22,11 +22,11 @@ struct TrackCell: View {
                 .aspectRatio(contentMode: .fit)
                 .frame(width: 38, height: 38, alignment: .center)
                 .padding()
-            TrackInfo(title: title, artist: artist)
+            TrackInfoView(title: title, artist: artist)
             Spacer()
             HStack(spacing: 20) {
-                Heart(isFavorite: isFavorite, toggleFavorite: didToggleFavorite)
-                Ellipsis()
+                HeartAccessoryView(isFavorite: isFavorite, toggleFavorite: didToggleFavorite)
+                EllipsisAccessoryView()
             }
             .padding(18)
         }
@@ -38,22 +38,22 @@ struct TrackCell: View {
 }
 
 extension TrackCell {
-    init(track: Track) {
+    init(track: Track, didToggleFavorite: (() -> Void)?) {
         title = track.title
         artist = track.artist
         isFavorite = track.isFavorite
         id = track.id
+        self.didToggleFavorite = didToggleFavorite
     }
 }
 
 
-struct Heart: View {
-    @State var isFavorite: Bool
+struct HeartAccessoryView: View {
+    var isFavorite: Bool
     let toggleFavorite: (() -> Void)?
     
     var body: some View {
         Button(action: {
-            self.isFavorite.toggle()
             toggleFavorite?()
         }, label: {
             Image(systemName: isFavorite ? "heart.fill" : "heart")
@@ -67,7 +67,7 @@ struct Heart: View {
     }
 }
 
-struct Ellipsis: View {
+struct EllipsisAccessoryView: View {
     var body: some View {
         Button(action: {
             print("show menu")
@@ -84,7 +84,7 @@ struct Ellipsis: View {
     }
 }
 
-struct TrackInfo: View {
+struct TrackInfoView: View {
     let title: String
     let artist: String
     
@@ -108,8 +108,8 @@ struct TrackCell_Previews: PreviewProvider {
         let testTrack2 = Track(id: 2, title: "마지막처럼", artist: "BLACKPINK", isFavorite: false)
 
         Group {
-            TrackCell(track: testTrack1)
-            TrackCell(track: testTrack2)
+            TrackCell(track: testTrack1, didToggleFavorite: nil)
+            TrackCell(track: testTrack2, didToggleFavorite: nil)
                 .preferredColorScheme(.dark)
 
         }

--- a/iOS/MiniVibe/MiniVibe/Views/TrackCell.swift
+++ b/iOS/MiniVibe/MiniVibe/Views/TrackCell.swift
@@ -1,0 +1,120 @@
+//
+//  TrackCell.swift
+//  DemoTrackView
+//
+//  Created by 강병민 on 2020/11/22.
+//
+
+import SwiftUI
+
+struct TrackCell: View {
+
+    let id: Int
+    let title: String
+    let artist: String
+    let isFavorite: Bool
+    var didToggleFavorite: (() -> Void)?
+
+    var body: some View {
+        HStack {
+            Image(systemName: "photo")
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(width: 38, height: 38, alignment: .center)
+                .padding()
+            TrackInfo(title: title, artist: artist)
+            Spacer()
+            HStack(spacing: 20) {
+                Heart(isFavorite: isFavorite, toggleFavorite: didToggleFavorite)
+                Ellipsis()
+            }
+            .padding(18)
+        }
+        .onTapGesture(perform: {
+            print("tapped \(title)")
+        })
+    }
+    
+}
+
+extension TrackCell {
+    init(track: Track) {
+        title = track.title
+        artist = track.artist
+        isFavorite = track.isFavorite
+        id = track.id
+    }
+}
+
+
+struct Heart: View {
+    @State var isFavorite: Bool
+    let toggleFavorite: (() -> Void)?
+    
+    var body: some View {
+        Button(action: {
+            self.isFavorite.toggle()
+            toggleFavorite?()
+        }, label: {
+            Image(systemName: isFavorite ? "heart.fill" : "heart")
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(width: 20, height: 20, alignment: .center)
+                .accentColor(.red)
+
+        })
+        .buttonStyle(BorderlessButtonStyle())
+    }
+}
+
+struct Ellipsis: View {
+    var body: some View {
+        Button(action: {
+            print("show menu")
+            
+        }, label: {
+            Image(systemName: "ellipsis")
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(width: 20, height: 20, alignment: .center)
+                .accentColor(.gray)
+
+        })
+        .buttonStyle(BorderlessButtonStyle())
+    }
+}
+
+struct TrackInfo: View {
+    let title: String
+    let artist: String
+    
+    var body: some View {
+        
+        VStack(alignment: .leading) {
+            Text(title)
+                .font(.headline)
+            Text(artist)
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+        }
+    }
+}
+
+ 
+struct NewsView_Previews: PreviewProvider {
+
+    static var previews: some View {
+        let testTrack1 = Track(id: 1, title: "휘파람", artist: "BLACKPINK", isFavorite: true)
+        let testTrack2 = Track(id: 2, title: "마지막처럼", artist: "BLACKPINK", isFavorite: false)
+
+        Group {
+            TrackCell(track: testTrack1)
+            TrackCell(track: testTrack2)
+                .preferredColorScheme(.dark)
+
+        }
+        .previewLayout(.sizeThatFits)
+    }
+}
+
+

--- a/iOS/MiniVibe/MiniVibe/Views/TrackCell.swift
+++ b/iOS/MiniVibe/MiniVibe/Views/TrackCell.swift
@@ -47,43 +47,6 @@ extension TrackCell {
     }
 }
 
-
-struct HeartAccessoryView: View {
-    var isFavorite: Bool
-    let toggleFavorite: (() -> Void)?
-    
-    var body: some View {
-        Button(action: {
-            toggleFavorite?()
-        }, label: {
-            Image(systemName: isFavorite ? "heart.fill" : "heart")
-                .resizable()
-                .aspectRatio(contentMode: .fit)
-                .frame(width: 20, height: 20, alignment: .center)
-                .accentColor(.red)
-
-        })
-        .buttonStyle(BorderlessButtonStyle())
-    }
-}
-
-struct EllipsisAccessoryView: View {
-    var body: some View {
-        Button(action: {
-            print("show menu")
-            
-        }, label: {
-            Image(systemName: "ellipsis")
-                .resizable()
-                .aspectRatio(contentMode: .fit)
-                .frame(width: 20, height: 20, alignment: .center)
-                .accentColor(.gray)
-
-        })
-        .buttonStyle(BorderlessButtonStyle())
-    }
-}
-
 struct TrackInfoView: View {
     let title: String
     let artist: String

--- a/iOS/MiniVibe/MiniVibe/Views/TrackListView.swift
+++ b/iOS/MiniVibe/MiniVibe/Views/TrackListView.swift
@@ -1,0 +1,34 @@
+//
+//  TrackListView.swift
+//  DemoTrackView
+//
+//  Created by 강병민 on 2020/11/22.
+//
+
+import SwiftUI
+
+struct TrackListView: View {
+    
+    @ObservedObject private var viewModel = TrackListViewModel()
+    
+    var body: some View {
+        List {
+            ForEach(viewModel.tracks) { track -> TrackCell in
+                var cell = TrackCell(track: track)
+                cell.didToggleFavorite = {
+                    viewModel.toggleIsFavorite(for: track.id)
+                }
+                return cell
+            }
+        }
+        .onAppear(perform: {
+            viewModel.fetchTracks()
+        })
+    }
+}
+
+struct TrackListView_Previews: PreviewProvider {
+    static var previews: some View {
+        TrackListView()
+    }
+}

--- a/iOS/MiniVibe/MiniVibe/Views/TrackListView.swift
+++ b/iOS/MiniVibe/MiniVibe/Views/TrackListView.swift
@@ -14,11 +14,9 @@ struct TrackListView: View {
     var body: some View {
         List {
             ForEach(viewModel.tracks) { track -> TrackCell in
-                var cell = TrackCell(track: track)
-                cell.didToggleFavorite = {
+                TrackCell(track: track, didToggleFavorite: {
                     viewModel.toggleIsFavorite(for: track.id)
-                }
-                return cell
+                })
             }
         }
         .onAppear(perform: {


### PR DESCRIPTION
>노래 목록을 보여줄 TrackListView 구현

## 구현내용
Tracklist를 SwiftUI와 Combine을 이용하여 구현했습니다
디자인패턴으로는 MVVM 패턴을 이용하였습니다.

### 화면
![image](https://user-images.githubusercontent.com/64558078/99958045-fb244000-2dcb-11eb-9896-d01197631db6.png)
### 학습 내용(optional)
SwiftUI와 Combine을 이용하여 구현했습니다
디자인 패턴은 ViewModel을 이용했습니다.

자세한 개발과정은 
[노래 track list를 만들어보자! (part1: SwiftUI를 이용하여 Cell 디자인하기)](https://github.com/boostcamp-2020/Project01-A-User-Event-Collector/wiki/%EB%85%B8%EB%9E%98-track-list%EB%A5%BC-%EB%A7%8C%EB%93%A4%EC%96%B4%EB%B3%B4%EC%9E%90!-(part1:-SwiftUI%EB%A5%BC-%EC%9D%B4%EC%9A%A9%ED%95%98%EC%97%AC-Cell-%EB%94%94%EC%9E%90%EC%9D%B8%ED%95%98%EA%B8%B0))

[노래 track list를 만들어보자! (part2: List로 보여주기 및 ViewModel적용하기)](https://github.com/boostcamp-2020/Project01-A-User-Event-Collector/wiki/%EB%85%B8%EB%9E%98-track-list%EB%A5%BC-%EB%A7%8C%EB%93%A4%EC%96%B4%EB%B3%B4%EC%9E%90!-(part2:-List%EB%A1%9C-%EB%B3%B4%EC%97%AC%EC%A3%BC%EA%B8%B0-%EB%B0%8F-ViewModel%EC%A0%81%EC%9A%A9%ED%95%98%EA%B8%B0))

를 참고해주세요

## 논의사항
현재 좋아요를 toggle할때 closure를 2번 넘거셔 구현하고있습니다
하지만 이렇게 closure가 여러번 넘겨지는것은 바람직하지 못하다고 느껴지네요
Combine 프레임워크를 이용하여 해결을 하고 싶은데 아직은 공부가 부곶해서 적용하지 못했습니다
