### PR TITLE
[iOS] DJStation 목록 화면 구현

### DIFF
--- a/iOS/MiniVibe/MiniVibe.xcodeproj/project.pbxproj
+++ b/iOS/MiniVibe/MiniVibe.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		51BEB332256F3C8600FB2876 /* DJStation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51BEB32F256F3C8600FB2876 /* DJStation.swift */; };
+		51BEB333256F3C8600FB2876 /* DJStationListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51BEB330256F3C8600FB2876 /* DJStationListViewModel.swift */; };
+		51BEB334256F3C8600FB2876 /* DJStationListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51BEB331256F3C8600FB2876 /* DJStationListView.swift */; };
 		CF05F8A82567E7AD008080D7 /* MiniVibeApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF05F8A72567E7AD008080D7 /* MiniVibeApp.swift */; };
 		CF05F8AA2567E7AD008080D7 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF05F8A92567E7AD008080D7 /* ContentView.swift */; };
 		CF05F8AC2567E7B0008080D7 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = CF05F8AB2567E7B0008080D7 /* Assets.xcassets */; };
@@ -35,6 +38,9 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		51BEB32F256F3C8600FB2876 /* DJStation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DJStation.swift; sourceTree = "<group>"; };
+		51BEB330256F3C8600FB2876 /* DJStationListViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DJStationListViewModel.swift; sourceTree = "<group>"; };
+		51BEB331256F3C8600FB2876 /* DJStationListView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DJStationListView.swift; sourceTree = "<group>"; };
 		CF05F8A42567E7AD008080D7 /* MiniVibe.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MiniVibe.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		CF05F8A72567E7AD008080D7 /* MiniVibeApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiniVibeApp.swift; sourceTree = "<group>"; };
 		CF05F8A92567E7AD008080D7 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -76,6 +82,16 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		51BEB32E256F3C8600FB2876 /* DJStation */ = {
+			isa = PBXGroup;
+			children = (
+				51BEB32F256F3C8600FB2876 /* DJStation.swift */,
+				51BEB330256F3C8600FB2876 /* DJStationListViewModel.swift */,
+				51BEB331256F3C8600FB2876 /* DJStationListView.swift */,
+			);
+			path = DJStation;
+			sourceTree = "<group>";
+		};
 		CF05F89B2567E7AD008080D7 = {
 			isa = PBXGroup;
 			children = (
@@ -103,6 +119,7 @@
 				CF05F8A92567E7AD008080D7 /* ContentView.swift */,
 				CF05F8AB2567E7B0008080D7 /* Assets.xcassets */,
 				CF05F8B02567E7B0008080D7 /* Persistence.swift */,
+				51BEB32E256F3C8600FB2876 /* DJStation */,
 				CF05F8B52567E7B0008080D7 /* Info.plist */,
 				CF05F8B22567E7B0008080D7 /* MiniVibe.xcdatamodeld */,
 				CF05F8AD2567E7B0008080D7 /* Preview Content */,
@@ -266,7 +283,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				CF05F8B42567E7B0008080D7 /* MiniVibe.xcdatamodeld in Sources */,
+				51BEB333256F3C8600FB2876 /* DJStationListViewModel.swift in Sources */,
 				CF05F8B12567E7B0008080D7 /* Persistence.swift in Sources */,
+				51BEB334256F3C8600FB2876 /* DJStationListView.swift in Sources */,
+				51BEB332256F3C8600FB2876 /* DJStation.swift in Sources */,
 				CF05F8AA2567E7AD008080D7 /* ContentView.swift in Sources */,
 				CF05F8A82567E7AD008080D7 /* MiniVibeApp.swift in Sources */,
 			);

--- a/iOS/MiniVibe/MiniVibe/DJStation/DJStation.swift
+++ b/iOS/MiniVibe/MiniVibe/DJStation/DJStation.swift
@@ -1,0 +1,14 @@
+//
+//  DJStation.swift
+//  MiniVibe
+//
+//  Created by 강병민 on 2020/11/25.
+//
+
+import Foundation
+
+struct DJStation: Identifiable {
+    let id: Int
+    let imageName: String
+    let title: String = "TEMP"
+}

--- a/iOS/MiniVibe/MiniVibe/DJStation/DJStationListView.swift
+++ b/iOS/MiniVibe/MiniVibe/DJStation/DJStationListView.swift
@@ -1,0 +1,40 @@
+//
+//  DJStationListView.swift
+//  MiniVibe
+//
+//  Created by 강병민 on 2020/11/26.
+//
+
+import SwiftUI
+
+struct DJStationListView: View {
+    
+    @StateObject var stationViewModel = DJStationListViewModel()
+    
+    let columns = [GridItem(.flexible(minimum: 50, maximum: .infinity)), GridItem(.flexible(minimum: 50, maximum: .infinity))]
+    
+    var body: some View {
+        ScrollView(.vertical) {
+            LazyVGrid(columns: columns) {
+                ForEach(stationViewModel.stations) { station in
+                    Button(action: {
+                    }, label: {
+                        Image(systemName: station.imageName)
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .frame(minHeight: 100)
+                    })
+                    .padding(.all, 30)
+                    .accentColor(.green)
+                }
+            }
+        }
+        .onAppear(perform: stationViewModel.fetchStations)
+    }
+}
+
+struct DJStationListView_Previews: PreviewProvider {
+    static var previews: some View {
+        DJStationListView()
+    }
+}

--- a/iOS/MiniVibe/MiniVibe/DJStation/DJStationListViewModel.swift
+++ b/iOS/MiniVibe/MiniVibe/DJStation/DJStationListViewModel.swift
@@ -1,0 +1,21 @@
+//
+//  DJStationListViewModel.swift
+//  MiniVibe
+//
+//  Created by 강병민 on 2020/11/26.
+//
+import Combine
+
+class DJStationListViewModel: ObservableObject {
+    @Published var stations = [DJStation]()
+    
+    func fetchStations() {
+        stations = [.init(id: 1, imageName: "shield.fill"),
+                    .init(id: 2, imageName: "hexagon.fill"),
+                    .init(id: 3, imageName: "triangle.fill"),
+                    .init(id: 4, imageName: "circle.fill"),
+                    .init(id: 5, imageName: "circle.fill"),
+                    .init(id: 6, imageName: "heart.fill"),
+        ]
+    }
+}


### PR DESCRIPTION
## 구현내용
Today 화면에서 DJStation 더보기를 누를때 나타나는 DJStation 목록 화면을 구현했습니다.
### 화면(optional)
![image](https://user-images.githubusercontent.com/64558078/100297915-1ad98500-2fd3-11eb-9e1b-37bb49159711.png)
![image](https://user-images.githubusercontent.com/64558078/100298013-5b390300-2fd3-11eb-9731-59017d9e16e1.png)

### 학습 내용(optional)
ViewModel도 만들었어요
## 논의사항
DJStation 모델은 임의로 만들었습니다만, Today화면의 CatagoryItem과 최대한 겹치게 만들었어요

## TODO
Today페이지와 연결하기