### PR TITLE
[iOS] NavigationBarStyle .foregroundColor(.primary) 제거

### DIFF
--- a/iOS/MiniVibe/MiniVibe/Scenes/Today/TodayView.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/Today/TodayView.swift
@@ -24,6 +24,7 @@ struct TodayView: View {
             .navigationTitle("VIBE")
         }
         .preferredColorScheme(.dark)
+        .navigationViewStyle(StackNavigationViewStyle())
     }
     
     func getDestination(from type: CategoryType) -> AnyView {

--- a/iOS/MiniVibe/MiniVibe/ViewModifier/NavigationBarStyle.swift
+++ b/iOS/MiniVibe/MiniVibe/ViewModifier/NavigationBarStyle.swift
@@ -14,6 +14,6 @@ struct NavigationBarStyle: ViewModifier {
         content
             .navigationTitle(title)
             .navigationBarTitleDisplayMode(.inline)
-            .foregroundColor(.primary)
+//            .foregroundColor(.primary)
     }
 }


### PR DESCRIPTION
>한줄 요약

## 구현내용
플레이리스트에서 트랙리스트로 넘어갈 때 하트 컬러가 프라이머리컬러에서 레드로 변경됨
바로 레드로 떠야하는데 프라이머리 컬러가 중간에 지정되었다 사라지는 문제 해결

### 학습 내용
```swift
struct NavigationBarStyle: ViewModifier {
    let title: String
    
    func body(content: Content) -> some View {
        content
            .navigationTitle(title)
            .navigationBarTitleDisplayMode(.inline)
//            .foregroundColor(.primary)
    }
}
```

`NavigationBarStyle`에서 `foregroundColor(.primary)` 제거

