### PR TITLE
[iOS] 전반적인 라우터 연결 및 Sticky Header 적용

### DIFF
--- a/iOS/MiniVibe/MiniVibe.xcodeproj/project.pbxproj
+++ b/iOS/MiniVibe/MiniVibe.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		CF2D94AF256F825B00D0A66B /* Track.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF2D94AB256F825B00D0A66B /* Track.swift */; };
 		CF2D94B0256F825B00D0A66B /* TrackListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF2D94AC256F825B00D0A66B /* TrackListView.swift */; };
 		CF2D94B1256F825B00D0A66B /* TrackListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF2D94AD256F825B00D0A66B /* TrackListViewModel.swift */; };
+		CF5C214A25741952007C7229 /* TodayRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF5C214925741952007C7229 /* TodayRouter.swift */; };
 		CF5E005B257241E80048F019 /* TrackListButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF5E005A257241E80048F019 /* TrackListButtonView.swift */; };
 		CF5E00602572441D0048F019 /* ButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF5E005F2572441D0048F019 /* ButtonStyle.swift */; };
 		CF5E006525724BA00048F019 /* TrackListHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF5E006425724BA00048F019 /* TrackListHeaderView.swift */; };
@@ -100,6 +101,7 @@
 		CF2D94AB256F825B00D0A66B /* Track.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Track.swift; sourceTree = "<group>"; };
 		CF2D94AC256F825B00D0A66B /* TrackListView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrackListView.swift; sourceTree = "<group>"; };
 		CF2D94AD256F825B00D0A66B /* TrackListViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrackListViewModel.swift; sourceTree = "<group>"; };
+		CF5C214925741952007C7229 /* TodayRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayRouter.swift; sourceTree = "<group>"; };
 		CF5E005A257241E80048F019 /* TrackListButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackListButtonView.swift; sourceTree = "<group>"; };
 		CF5E005F2572441D0048F019 /* ButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonStyle.swift; sourceTree = "<group>"; };
 		CF5E006425724BA00048F019 /* TrackListHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackListHeaderView.swift; sourceTree = "<group>"; };
@@ -185,6 +187,7 @@
 				51EED2DC256F7E3C00DB32CB /* Category.swift */,
 				51EED2DD256F7E3C00DB32CB /* TodayView.swift */,
 				51EED2DE256F7E3C00DB32CB /* CategoryCellView.swift */,
+				CF5C214925741952007C7229 /* TodayRouter.swift */,
 			);
 			path = Today;
 			sourceTree = "<group>";
@@ -468,6 +471,7 @@
 				CF93D7BE256E660D005A71CF /* NavigationBarStyle.swift in Sources */,
 				CF93D7D0256E7FE6005A71CF /* PlaylistListViewModel.swift in Sources */,
 				CF2D94B0256F825B00D0A66B /* TrackListView.swift in Sources */,
+				CF5C214A25741952007C7229 /* TodayRouter.swift in Sources */,
 				51BEB333256F3C8600FB2876 /* DJStationListViewModel.swift in Sources */,
 				51D6C6EF2572220300EF1B26 /* Image+accesoryModifier.swift in Sources */,
 				CF2D94AE256F825B00D0A66B /* TrackCellView.swift in Sources */,

--- a/iOS/MiniVibe/MiniVibe.xcodeproj/project.pbxproj
+++ b/iOS/MiniVibe/MiniVibe.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		CF2D94B0256F825B00D0A66B /* TrackListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF2D94AC256F825B00D0A66B /* TrackListView.swift */; };
 		CF2D94B1256F825B00D0A66B /* TrackListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF2D94AD256F825B00D0A66B /* TrackListViewModel.swift */; };
 		CF5C214A25741952007C7229 /* TodayRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF5C214925741952007C7229 /* TodayRouter.swift */; };
+		CF5C214F25741BEE007C7229 /* CategoryRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF5C214E25741BEE007C7229 /* CategoryRouter.swift */; };
 		CF5E005B257241E80048F019 /* TrackListButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF5E005A257241E80048F019 /* TrackListButtonView.swift */; };
 		CF5E00602572441D0048F019 /* ButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF5E005F2572441D0048F019 /* ButtonStyle.swift */; };
 		CF5E006525724BA00048F019 /* TrackListHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF5E006425724BA00048F019 /* TrackListHeaderView.swift */; };
@@ -102,6 +103,7 @@
 		CF2D94AC256F825B00D0A66B /* TrackListView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrackListView.swift; sourceTree = "<group>"; };
 		CF2D94AD256F825B00D0A66B /* TrackListViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrackListViewModel.swift; sourceTree = "<group>"; };
 		CF5C214925741952007C7229 /* TodayRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayRouter.swift; sourceTree = "<group>"; };
+		CF5C214E25741BEE007C7229 /* CategoryRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryRouter.swift; sourceTree = "<group>"; };
 		CF5E005A257241E80048F019 /* TrackListButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackListButtonView.swift; sourceTree = "<group>"; };
 		CF5E005F2572441D0048F019 /* ButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonStyle.swift; sourceTree = "<group>"; };
 		CF5E006425724BA00048F019 /* TrackListHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackListHeaderView.swift; sourceTree = "<group>"; };
@@ -188,6 +190,7 @@
 				51EED2DD256F7E3C00DB32CB /* TodayView.swift */,
 				51EED2DE256F7E3C00DB32CB /* CategoryCellView.swift */,
 				CF5C214925741952007C7229 /* TodayRouter.swift */,
+				CF5C214E25741BEE007C7229 /* CategoryRouter.swift */,
 			);
 			path = Today;
 			sourceTree = "<group>";
@@ -472,6 +475,7 @@
 				CF93D7D0256E7FE6005A71CF /* PlaylistListViewModel.swift in Sources */,
 				CF2D94B0256F825B00D0A66B /* TrackListView.swift in Sources */,
 				CF5C214A25741952007C7229 /* TodayRouter.swift in Sources */,
+				CF5C214F25741BEE007C7229 /* CategoryRouter.swift in Sources */,
 				51BEB333256F3C8600FB2876 /* DJStationListViewModel.swift in Sources */,
 				51D6C6EF2572220300EF1B26 /* Image+accesoryModifier.swift in Sources */,
 				CF2D94AE256F825B00D0A66B /* TrackCellView.swift in Sources */,

--- a/iOS/MiniVibe/MiniVibe/Scenes/Player/PlayerView.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/Player/PlayerView.swift
@@ -48,9 +48,9 @@ struct PlayerInfoView: View {
             HStack {
                 VStack (alignment: .leading){
                     Text(track.title)
-                        .modifier(Title())
+                        .modifier(Title2())
                     Text(track.artist)
-                        .modifier(Description())
+                        .modifier(Description2())
                 }
                 Spacer()
                 Image(systemName: "ellipsis")

--- a/iOS/MiniVibe/MiniVibe/Scenes/Playlist/PlaylistRouter.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/Playlist/PlaylistRouter.swift
@@ -27,9 +27,9 @@ class PlaylistRouter: StarterOrientedRouterProtocol {
         case .magazines:
             return AnyView(TrackListView(id: 1))
         case .recommended:
-            return AnyView(TrackListView(id: 1))
+            return AnyView(PlaylistView())
         case .favorites:
-            return AnyView(TrackListView(id: 1))
+            return AnyView(PlaylistView())
         }
     }
     

--- a/iOS/MiniVibe/MiniVibe/Scenes/Playlist/PlaylistRouter.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/Playlist/PlaylistRouter.swift
@@ -7,13 +7,13 @@
 
 import SwiftUI
 
-enum PlaylistRoutingStarter: RoutingStarterProtocol {
+enum PlaylistRoutingStarter: RoutingTypeProtocol {
     case magazines
     case recommended
     case favorites
 }
 
-class PlaylistRouter: RouterProtocol {
+class PlaylistRouter: StarterOrientedRouterProtocol {
     typealias RoutingStarter = PlaylistRoutingStarter
     
     let routingStarter: RoutingStarter

--- a/iOS/MiniVibe/MiniVibe/Scenes/Playlist/PlaylistView.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/Playlist/PlaylistView.swift
@@ -9,14 +9,22 @@ import SwiftUI
 
 struct PlaylistView: View {
     private let playlist = Playlist(id: 1, title: "Dynamite", imageUrl: "Dynamite", description: "아무 생각 없이 드라이브하며 기분전환 어쩌고 저쩌고 dkdkdkdkdk", createdAt: "어제 어쩌고", author: "VIBE")
+    private let trackListId: Int = 1
+    private let layout = [GridItem(.flexible())]
     
-    
+//    init(playlist: Playlist, trackListId: Int) {
+//        self.playlist = playlist
+//        self.trackListId = trackListId
+//    }
     
     var body: some View {
-        VStack {
-            TrackListHeaderView(playlist: playlist)
-            TrackListButtonView()
-            TrackListView(id: 1)
+        ScrollView {
+            LazyVGrid(columns: layout, pinnedViews: [.sectionHeaders]) {
+                TrackListHeaderView(playlist: playlist)
+                Section(header: TrackListButtonView()) {
+                    TrackListView(id: trackListId)
+                }
+            }
         }.padding()
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {

--- a/iOS/MiniVibe/MiniVibe/Scenes/Router/RouterProtocol.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/Router/RouterProtocol.swift
@@ -7,11 +7,16 @@
 
 import SwiftUI
 
-protocol RoutingStarterProtocol {
+protocol RoutingTypeProtocol {
     
 }
 
-protocol RouterProtocol {
+protocol StarterOrientedRouterProtocol {
     associatedtype RoutingStarter
     func getDestination() -> AnyView
+}
+
+protocol DestinationOrientedRouterProtocol {
+    associatedtype RoutingType
+    func getDestination(to routingDestination: RoutingType) -> AnyView
 }

--- a/iOS/MiniVibe/MiniVibe/Scenes/Today/Category.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/Today/Category.swift
@@ -7,10 +7,6 @@
 
 import Foundation
 
-enum CategoryType {
-    case track, playlist, magazine, station
-}
-
 enum CategoryMode {
     case full, half
 }
@@ -19,6 +15,6 @@ struct Category: Identifiable {
     let id = UUID()
     let title: String
     let items: [CategoryCell]
-    let type: CategoryType
+    let type: TodayRoutingType
     let mode: CategoryMode
 }

--- a/iOS/MiniVibe/MiniVibe/Scenes/Today/CategoryRouter.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/Today/CategoryRouter.swift
@@ -1,0 +1,25 @@
+//
+//  CategoryRouter.swift
+//  MiniVibe
+//
+//  Created by 류연수 on 2020/11/30.
+//
+
+import SwiftUI
+
+class CategoryRouter: DestinationOrientedRouterProtocol {
+    typealias RoutingType = TodayRoutingType
+    
+    func getDestination(to routingDestination: TodayRoutingType) -> AnyView {
+        //TODO: 타입에따라서 다른 destination 보여주게하기! (대부분 id넘겨서 tracklist 보여주기
+        switch routingDestination {
+        case .magazines:
+            return AnyView(Text("매거진 화면 보여주기")
+                            .bold())
+        case .playlists:
+            return AnyView(PlaylistView())
+        default:
+            return AnyView(Text("기본 화면"))
+        }
+    }
+}

--- a/iOS/MiniVibe/MiniVibe/Scenes/Today/CategoryView.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/Today/CategoryView.swift
@@ -28,7 +28,7 @@ struct CategoryView: View {
         .padding(.bottom, 30)
     }
     
-    func getDestination(from type: CategoryType) -> AnyView {
+    func getDestination(from type: TodayRoutingType) -> AnyView {
         //TODO: 타입에따라서 다른 destination 보여주게하기! (대부분 id넘겨서 tracklist 보여주기
         switch type {
         case .magazine:

--- a/iOS/MiniVibe/MiniVibe/Scenes/Today/CategoryView.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/Today/CategoryView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct CategoryView: View {
     let category: Category
+    private let router = CategoryRouter()
     
     var body: some View {
         VStack(alignment: .leading) {
@@ -17,7 +18,7 @@ struct CategoryView: View {
                 HStack(alignment: .top, spacing: 10) {
                     ForEach(category.items) { item in
                         NavigationLink(
-                            destination: getDestination(from: category.type)
+                            destination: router.getDestination(to: category.type)
                         ) {
                             CategoryCellView(item: item, mode: category.mode)
                         }
@@ -26,19 +27,6 @@ struct CategoryView: View {
             }
         }
         .padding(.bottom, 30)
-    }
-    
-    func getDestination(from type: TodayRoutingType) -> AnyView {
-        //TODO: 타입에따라서 다른 destination 보여주게하기! (대부분 id넘겨서 tracklist 보여주기
-        switch type {
-        case .magazine:
-            return AnyView(Text("매거진 화면 보여주기")
-                            .bold())
-        case .playlist:
-            return AnyView(PlaylistView())
-        default:
-            return AnyView(Text("기본 화면"))
-        }
     }
     
 }
@@ -52,7 +40,7 @@ struct CategoryRowView_Previews: PreviewProvider {
 
     static var previews: some View {
         NavigationView {
-            CategoryView(category: Category(title: "Station", items: favoritePlaylistItems, type: .station, mode: .full))
+            CategoryView(category: Category(title: "Station", items: favoritePlaylistItems, type: .stations, mode: .full))
         }
 //        .preferredColorScheme(.dark)
     }

--- a/iOS/MiniVibe/MiniVibe/Scenes/Today/TodayRouter.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/Today/TodayRouter.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 enum TodayRoutingType: RoutingTypeProtocol {
-    case track, playlist, magazine, station
+    case tracks, playlists, magazines, stations
 }
 
 class TodayRouter: DestinationOrientedRouterProtocol {
@@ -16,15 +16,15 @@ class TodayRouter: DestinationOrientedRouterProtocol {
     
     func getDestination(to routingDestination: RoutingStarter) -> AnyView {
         switch routingDestination {
-        case .magazine:
+        case .magazines:
             return AnyView(PlaylistListView(id: 1,
                                             router: PlaylistRouter(routingStarter: .magazines)))
-        case .playlist:
+        case .playlists:
             return AnyView(PlaylistListView(id: 1,
                                             router: PlaylistRouter(routingStarter: .recommended)))
-        case .station:
+        case .stations:
             return AnyView(DJStationListView())
-        case .track:
+        case .tracks:
             return AnyView(TrackListView(id: 1))
         }
     }

--- a/iOS/MiniVibe/MiniVibe/Scenes/Today/TodayRouter.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/Today/TodayRouter.swift
@@ -1,0 +1,31 @@
+//
+//  TodayRouter.swift
+//  MiniVibe
+//
+//  Created by 류연수 on 2020/11/30.
+//
+
+import SwiftUI
+
+enum TodayRoutingType: RoutingTypeProtocol {
+    case track, playlist, magazine, station
+}
+
+class TodayRouter: DestinationOrientedRouterProtocol {
+    typealias RoutingStarter = TodayRoutingType
+    
+    func getDestination(to routingDestination: RoutingStarter) -> AnyView {
+        switch routingDestination {
+        case .magazine:
+            return AnyView(PlaylistListView(id: 1,
+                                            router: PlaylistRouter(routingStarter: .magazines)))
+        case .playlist:
+            return AnyView(PlaylistListView(id: 1,
+                                            router: PlaylistRouter(routingStarter: .recommended)))
+        case .station:
+            return AnyView(DJStationListView())
+        case .track:
+            return AnyView(TrackListView(id: 1))
+        }
+    }
+}

--- a/iOS/MiniVibe/MiniVibe/Scenes/Today/TodayView.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/Today/TodayView.swift
@@ -8,12 +8,14 @@
 import SwiftUI
 
 struct TodayView: View {
+    private let router = TodayRouter()
+    
     var body: some View {
         NavigationView {
             List {
                 ForEach(TestData.categories) { category in
                     NavigationLink(
-                        destination: getDestination(from: category.type),
+                        destination: router.getDestination(to: category.type),
                         label: {
                             CategoryView(category: category)
                         }
@@ -26,21 +28,6 @@ struct TodayView: View {
         .preferredColorScheme(.dark)
         .navigationViewStyle(StackNavigationViewStyle())
     }
-    
-    func getDestination(from type: CategoryType) -> AnyView {
-        // 타입에따라서 다른 destination 보여주게하기!
-        switch type {
-        case .magazine:
-            return AnyView(PlaylistListView(id: 1, router: PlaylistRouter(routingStarter: .magazines)))
-        case .playlist:
-            return AnyView(PlaylistListView(id: 1, router: PlaylistRouter(routingStarter: .recommended)))
-        case .station:
-            return AnyView(DJStationListView())
-        case .track:
-            return AnyView(TrackListView(id: 1))
-        }
-    }
-    
 }
 
 struct TodayView_Previews: PreviewProvider {

--- a/iOS/MiniVibe/MiniVibe/Scenes/Today/TodayView.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/Today/TodayView.swift
@@ -65,19 +65,19 @@ struct TestData {
     static let categories: [Category]
         = [.init(title: "DJ 스테이션",
                  items: stationItems,
-                 type: .station,
+                 type: .stations,
                  mode: .half),
            .init(title: "VIBE 추천 플레이리스트",
                     items: recomendPlaylistItems,
-                    type: .playlist,
+                    type: .playlists,
                     mode: .full),
            .init(title: "즐겨찾는 플레이리스트",
                     items: favoritePlaylistItems,
-                    type: .playlist,
+                    type: .playlists,
                     mode: .half),
             .init(title: "VIBE MAG",
                      items: magazineItems,
-                     type: .magazine,
+                     type: .magazines,
                      mode: .full),
         ]
 }

--- a/iOS/MiniVibe/MiniVibe/Scenes/TrackList/TrackCellView.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/TrackList/TrackCellView.swift
@@ -71,9 +71,9 @@ struct TrackInfoView: View {
                 .padding(.horizontal, 10)
             VStack(alignment: .leading) {
                 Text(title)
-                    .modifier(Title())
+                    .modifier(Title2())
                 Text(artist)
-                    .modifier(Description())
+                    .modifier(Description2())
             }
             Spacer()
         }

--- a/iOS/MiniVibe/MiniVibe/Scenes/TrackList/TrackCellView.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/TrackList/TrackCellView.swift
@@ -68,7 +68,7 @@ struct TrackInfoView: View {
                 .aspectRatio(contentMode: .fit)
                 .frame(width: 44, height: 44, alignment: .center)
                 .padding(.vertical, 2)
-                .padding(.horizontal, 10)
+//                .padding(.horizontal, 10)
             VStack(alignment: .leading) {
                 Text(title)
                     .modifier(Title2())

--- a/iOS/MiniVibe/MiniVibe/Scenes/TrackList/TrackListButtonView.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/TrackList/TrackListButtonView.swift
@@ -17,8 +17,8 @@ struct TrackListButtonView: View {
                     Image(systemName: "play.fill")
                     Text("PLAY")
                         .modifier(Title2())
-                }
-            }.modifier(TrackListButtonStyle())
+                }.modifier(TrackListButtonStyle())
+            }
             Button(action: {
                 // action
             }) {
@@ -26,8 +26,8 @@ struct TrackListButtonView: View {
                     Image(systemName: "shuffle")
                     Text("SHUFFLE")
                         .modifier(Title2())
-                }
-            }.modifier(TrackListButtonStyle())
+                }.modifier(TrackListButtonStyle())
+            }
         }
     }
 }

--- a/iOS/MiniVibe/MiniVibe/Scenes/TrackList/TrackListView.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/TrackList/TrackListView.swift
@@ -17,7 +17,7 @@ struct TrackListView: View {
     }
     
     var body: some View {
-        List {
+        LazyVStack {
             ForEach(viewModel.tracks) { track -> TrackCellView in
                 var cell = TrackCellView(track: track)
                 cell.didToggleFavorite = {

--- a/iOS/MiniVibe/MiniVibe/ViewModifier/ButtonStyle.swift
+++ b/iOS/MiniVibe/MiniVibe/ViewModifier/ButtonStyle.swift
@@ -13,7 +13,7 @@ struct TrackListButtonStyle: ViewModifier {
             .padding()
             .frame(maxWidth: .infinity)
             .foregroundColor(.primary)
-            .background(Color.secondary)
+            .background(Color(UIColor.systemGray6))
             .cornerRadius(6.0)
     }
 }


### PR DESCRIPTION
>내일 수정할게요

## 구현내용

### 화면
<img width="286" alt="StickyHeader" src="https://user-images.githubusercontent.com/60538517/100550496-9da55d00-32bd-11eb-9c35-2c9eb68b2229.gif">

###  LazyVGrid를 사용한 이유

```swift
List {
    TrackListHeaderView(playlist: playlist)
    Section(header: TrackListButtonView()) {
        TrackListView(id: trackListId)
    }
}
```

`List`를 사용했을 때에는 헤더의 백그라운드 컬러가 기본적으로 지정된다. 이를 커스터마이징하는데 야크털깎는 노동력이 필요하여 `Grid`를 사용하였다.
<img width="317" alt="스크린샷 2020-11-30 오후 2 07 00" src="https://user-images.githubusercontent.com/60538517/100571154-c78a6e00-3315-11eb-8d50-f75f137e0318.png">

```swift
ScrollView {
    LazyVGrid(columns: layout, pinnedViews: [.sectionHeaders]) {
        TrackListHeaderView(playlist: playlist)
        Section(header: TrackListButtonView()) {
            TrackListView(id: trackListId)
        }
    }
}.padding()
.navigationBarTitleDisplayMode(.inline)
.toolbar {
    ToolbarItem(placement: .principal) {
        VStack {
            Text(playlist.title)
                .modifier(Title2())
            if let author = playlist.author {
                Text(author)
                    .modifier(Description2())
            }
        }
    }
}
```
기존 `NavigationBar Inline Title`은 한 줄의 텍스트만 지정 가능하다. 두 줄을 넣는 방식으로 커스터마이징하기 위하여 `ToolBar`를 활용하였다.

### TrackList를 List에서 LazyVStack로 변경

```swift
LazyVStack {
    ForEach(viewModel.tracks) { track -> TrackCellView in
        var cell = TrackCellView(track: track)
        cell.didToggleFavorite = {
            viewModel.toggleIsFavorite(for: track.id)
        }
        return cell
    }
}
```

## 논의사항
네이밍 컨벤션 정리가 필요합니당❗️
