### PR TITLE
[iOS] 검색 후에 나오는 뷰 생성

### DIFF
--- a/iOS/MiniVibe/MiniVibe.xcodeproj/project.pbxproj
+++ b/iOS/MiniVibe/MiniVibe.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		CF2D94AE256F825B00D0A66B /* TrackCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF2D94AA256F825B00D0A66B /* TrackCellView.swift */; };
 		CF2D94B0256F825B00D0A66B /* TrackListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF2D94AC256F825B00D0A66B /* TrackListView.swift */; };
 		CF2D94B1256F825B00D0A66B /* TrackListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF2D94AD256F825B00D0A66B /* TrackListViewModel.swift */; };
+		CF3BDD632576AA6100FF768E /* SearchAfterCategoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF3BDD622576AA6100FF768E /* SearchAfterCategoryView.swift */; };
 		CF5C214A25741952007C7229 /* TodayRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF5C214925741952007C7229 /* TodayRouter.swift */; };
 		CF5C214F25741BEE007C7229 /* CategoryRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF5C214E25741BEE007C7229 /* CategoryRouter.swift */; };
 		CF5E005B257241E80048F019 /* TrackListButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF5E005A257241E80048F019 /* TrackListButtonView.swift */; };
@@ -136,6 +137,7 @@
 		CF2D94AA256F825B00D0A66B /* TrackCellView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrackCellView.swift; sourceTree = "<group>"; };
 		CF2D94AC256F825B00D0A66B /* TrackListView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrackListView.swift; sourceTree = "<group>"; };
 		CF2D94AD256F825B00D0A66B /* TrackListViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrackListViewModel.swift; sourceTree = "<group>"; };
+		CF3BDD622576AA6100FF768E /* SearchAfterCategoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchAfterCategoryView.swift; sourceTree = "<group>"; };
 		CF5C214925741952007C7229 /* TodayRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayRouter.swift; sourceTree = "<group>"; };
 		CF5C214E25741BEE007C7229 /* CategoryRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryRouter.swift; sourceTree = "<group>"; };
 		CF5E005A257241E80048F019 /* TrackListButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackListButtonView.swift; sourceTree = "<group>"; };
@@ -392,6 +394,7 @@
 				CF6E5DD525756A3300BE7503 /* RectangleListView.swift */,
 				CF6E5DDA25756BAC00BE7503 /* GenreCellView.swift */,
 				CF6E5DE225756E6300BE7503 /* GenreListView.swift */,
+				CF3BDD622576AA6100FF768E /* SearchAfterCategoryView.swift */,
 			);
 			path = Search;
 			sourceTree = "<group>";
@@ -567,6 +570,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				CF05F8B42567E7B0008080D7 /* MiniVibe.xcdatamodeld in Sources */,
+				CF3BDD632576AA6100FF768E /* SearchAfterCategoryView.swift in Sources */,
 				CF93D7D9256E9009005A71CF /* Sequence+indexed.swift in Sources */,
 				CF8286A2256BA5BA00D68373 /* ThumbnailCellView.swift in Sources */,
 				515D26752575224A00B542BF /* TestData.swift in Sources */,

--- a/iOS/MiniVibe/MiniVibe.xcodeproj/project.pbxproj
+++ b/iOS/MiniVibe/MiniVibe.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		CF2D94B0256F825B00D0A66B /* TrackListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF2D94AC256F825B00D0A66B /* TrackListView.swift */; };
 		CF2D94B1256F825B00D0A66B /* TrackListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF2D94AD256F825B00D0A66B /* TrackListViewModel.swift */; };
 		CF3BDD632576AA6100FF768E /* SearchAfterCategoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF3BDD622576AA6100FF768E /* SearchAfterCategoryView.swift */; };
+		CF3BDD682576BAB500FF768E /* SearchAfterCategoriesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF3BDD672576BAB500FF768E /* SearchAfterCategoriesView.swift */; };
 		CF5C214A25741952007C7229 /* TodayRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF5C214925741952007C7229 /* TodayRouter.swift */; };
 		CF5C214F25741BEE007C7229 /* CategoryRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF5C214E25741BEE007C7229 /* CategoryRouter.swift */; };
 		CF5E005B257241E80048F019 /* TrackListButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF5E005A257241E80048F019 /* TrackListButtonView.swift */; };
@@ -138,6 +139,7 @@
 		CF2D94AC256F825B00D0A66B /* TrackListView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrackListView.swift; sourceTree = "<group>"; };
 		CF2D94AD256F825B00D0A66B /* TrackListViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrackListViewModel.swift; sourceTree = "<group>"; };
 		CF3BDD622576AA6100FF768E /* SearchAfterCategoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchAfterCategoryView.swift; sourceTree = "<group>"; };
+		CF3BDD672576BAB500FF768E /* SearchAfterCategoriesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchAfterCategoriesView.swift; sourceTree = "<group>"; };
 		CF5C214925741952007C7229 /* TodayRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayRouter.swift; sourceTree = "<group>"; };
 		CF5C214E25741BEE007C7229 /* CategoryRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryRouter.swift; sourceTree = "<group>"; };
 		CF5E005A257241E80048F019 /* TrackListButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackListButtonView.swift; sourceTree = "<group>"; };
@@ -395,6 +397,7 @@
 				CF6E5DDA25756BAC00BE7503 /* GenreCellView.swift */,
 				CF6E5DE225756E6300BE7503 /* GenreListView.swift */,
 				CF3BDD622576AA6100FF768E /* SearchAfterCategoryView.swift */,
+				CF3BDD672576BAB500FF768E /* SearchAfterCategoriesView.swift */,
 			);
 			path = Search;
 			sourceTree = "<group>";
@@ -625,6 +628,7 @@
 				CF2D94B1256F825B00D0A66B /* TrackListViewModel.swift in Sources */,
 				5181EA802570A0DC0077A727 /* NowPlayingView.swift in Sources */,
 				CF6E5DD625756A3300BE7503 /* RectangleListView.swift in Sources */,
+				CF3BDD682576BAB500FF768E /* SearchAfterCategoriesView.swift in Sources */,
 				CF5E006525724BA00048F019 /* TrackListHeaderView.swift in Sources */,
 				51D6C6E225721D7A00EF1B26 /* TabBarView.swift in Sources */,
 				CF6E5D962574E8C400BE7503 /* NetworkService.swift in Sources */,

--- a/iOS/MiniVibe/MiniVibe.xcodeproj/project.pbxproj
+++ b/iOS/MiniVibe/MiniVibe.xcodeproj/project.pbxproj
@@ -48,7 +48,7 @@
 		CF2D94B0256F825B00D0A66B /* TrackListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF2D94AC256F825B00D0A66B /* TrackListView.swift */; };
 		CF2D94B1256F825B00D0A66B /* TrackListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF2D94AD256F825B00D0A66B /* TrackListViewModel.swift */; };
 		CF3BDD632576AA6100FF768E /* SearchAfterCategoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF3BDD622576AA6100FF768E /* SearchAfterCategoryView.swift */; };
-		CF3BDD682576BAB500FF768E /* SearchAfterCategoriesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF3BDD672576BAB500FF768E /* SearchAfterCategoriesView.swift */; };
+		CF3BDD682576BAB500FF768E /* SearchAfterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF3BDD672576BAB500FF768E /* SearchAfterView.swift */; };
 		CF5C214A25741952007C7229 /* TodayRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF5C214925741952007C7229 /* TodayRouter.swift */; };
 		CF5C214F25741BEE007C7229 /* CategoryRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF5C214E25741BEE007C7229 /* CategoryRouter.swift */; };
 		CF5E005B257241E80048F019 /* TrackListButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF5E005A257241E80048F019 /* TrackListButtonView.swift */; };
@@ -139,7 +139,7 @@
 		CF2D94AC256F825B00D0A66B /* TrackListView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrackListView.swift; sourceTree = "<group>"; };
 		CF2D94AD256F825B00D0A66B /* TrackListViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrackListViewModel.swift; sourceTree = "<group>"; };
 		CF3BDD622576AA6100FF768E /* SearchAfterCategoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchAfterCategoryView.swift; sourceTree = "<group>"; };
-		CF3BDD672576BAB500FF768E /* SearchAfterCategoriesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchAfterCategoriesView.swift; sourceTree = "<group>"; };
+		CF3BDD672576BAB500FF768E /* SearchAfterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchAfterView.swift; sourceTree = "<group>"; };
 		CF5C214925741952007C7229 /* TodayRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayRouter.swift; sourceTree = "<group>"; };
 		CF5C214E25741BEE007C7229 /* CategoryRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryRouter.swift; sourceTree = "<group>"; };
 		CF5E005A257241E80048F019 /* TrackListButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackListButtonView.swift; sourceTree = "<group>"; };
@@ -397,7 +397,7 @@
 				CF6E5DDA25756BAC00BE7503 /* GenreCellView.swift */,
 				CF6E5DE225756E6300BE7503 /* GenreListView.swift */,
 				CF3BDD622576AA6100FF768E /* SearchAfterCategoryView.swift */,
-				CF3BDD672576BAB500FF768E /* SearchAfterCategoriesView.swift */,
+				CF3BDD672576BAB500FF768E /* SearchAfterView.swift */,
 			);
 			path = Search;
 			sourceTree = "<group>";
@@ -628,7 +628,7 @@
 				CF2D94B1256F825B00D0A66B /* TrackListViewModel.swift in Sources */,
 				5181EA802570A0DC0077A727 /* NowPlayingView.swift in Sources */,
 				CF6E5DD625756A3300BE7503 /* RectangleListView.swift in Sources */,
-				CF3BDD682576BAB500FF768E /* SearchAfterCategoriesView.swift in Sources */,
+				CF3BDD682576BAB500FF768E /* SearchAfterView.swift in Sources */,
 				CF5E006525724BA00048F019 /* TrackListHeaderView.swift in Sources */,
 				51D6C6E225721D7A00EF1B26 /* TabBarView.swift in Sources */,
 				CF6E5D962574E8C400BE7503 /* NetworkService.swift in Sources */,

--- a/iOS/MiniVibe/MiniVibe/Scenes/Search/RectangleCellInfoView.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/Search/RectangleCellInfoView.swift
@@ -16,9 +16,8 @@ struct RectangleCellInfoView: View {
                 Text("EXO 카이가 솔로 데뷔곡 MV를 선공개했습니다.")
                     .multilineTextAlignment(.leading)
                     .font(.system(size: 18, weight: .bold))
-                    .lineLimit(3)
+                    .lineLimit(2)
                     .padding([.leading, .top])
-                    .frame(maxWidth: 195)
                 Spacer()
             }
             HStack {

--- a/iOS/MiniVibe/MiniVibe/Scenes/Search/SearchAfterCategoriesView.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/Search/SearchAfterCategoriesView.swift
@@ -1,0 +1,48 @@
+//
+//  SearchAfterCategoriesView.swift
+//  MiniVibe
+//
+//  Created by 류연수 on 2020/12/02.
+//
+
+import SwiftUI
+
+struct SearchAfterCategoriesView: View {
+    private let tracks: [Track]?
+    private let albums: [Album]?
+    private let artists: [Artist]?
+    
+    init(tracks: [Track]?, albums: [Album]?, artists: [Artist]?) {
+        self.tracks = tracks
+        self.albums = albums
+        self.artists = artists
+    }
+    
+    var body: some View {
+        ScrollView {
+            LazyVGrid(columns: [GridItem(.flexible())],
+                      spacing: 40,
+                      pinnedViews: [.sectionHeaders]) {
+                Section(header: SearchBarView(text: .constant(""))) {
+                    if let tracks = tracks {
+                        SearchAfterCategoryView(type: .track, tracks: tracks)
+                        SearchAfterCategoryView(type: .album, tracks: tracks)
+                        SearchAfterCategoryView(type: .artist, tracks: tracks)
+                    }
+            //        if let albums = albums {
+            //            SearchAfterCategoryView(type: .album, tracks: albums)
+            //        }
+            //        if let artists = artists {
+            //            SearchAfterCategoryView(type: .artist, tracks: artists)
+            //        }
+                }
+            }
+        }.padding()
+    }
+}
+
+struct SearchAfterCategoriesView_Previews: PreviewProvider {
+    static var previews: some View {
+        SearchAfterCategoriesView(tracks: TestData.playlist.tracks, albums: nil, artists: nil)
+    }
+}

--- a/iOS/MiniVibe/MiniVibe/Scenes/Search/SearchAfterCategoryView.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/Search/SearchAfterCategoryView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct SearchAfterCategoryView: View {
+    private let maxCountOfTracks = 3
     private let type: CategoryType
     private let tracks: [Track]
     
@@ -28,7 +29,7 @@ struct SearchAfterCategoryView: View {
                     .modifier(Title1())
                 Spacer()
             }
-            let n = tracks.count >= 3 ? 3 : tracks.count
+            let n = tracks.count >= maxCountOfTracks ? maxCountOfTracks : tracks.count
             ForEach(tracks[0..<n]) { track in
                 TrackCellView(track: track)
             }

--- a/iOS/MiniVibe/MiniVibe/Scenes/Search/SearchAfterCategoryView.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/Search/SearchAfterCategoryView.swift
@@ -13,12 +13,7 @@ struct SearchAfterCategoryView: View {
     
     init(type: CategoryType, tracks: [Track]) {
         self.type = type
-        if tracks.count > 3 {
-            self.tracks = Array(tracks[0..<3])
-        }
-        else {
-            self.tracks = tracks
-        }
+        self.tracks = tracks
     }
     
     enum CategoryType: String {
@@ -33,7 +28,8 @@ struct SearchAfterCategoryView: View {
                     .modifier(Title1())
                 Spacer()
             }
-            ForEach(tracks) { track in
+            let n = tracks.count >= 3 ? 3 : tracks.count
+            ForEach(tracks[0..<n]) { track in
                 TrackCellView(track: track)
             }
         }

--- a/iOS/MiniVibe/MiniVibe/Scenes/Search/SearchAfterCategoryView.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/Search/SearchAfterCategoryView.swift
@@ -1,0 +1,47 @@
+//
+//  SearchAfterCategoryView.swift
+//  MiniVibe
+//
+//  Created by 류연수 on 2020/12/02.
+//
+
+import SwiftUI
+
+struct SearchAfterCategoryView: View {
+    private let type: CategoryType
+    private let tracks: [Track]
+    
+    init(type: CategoryType, tracks: [Track]) {
+        self.type = type
+        if tracks.count > 3 {
+            self.tracks = Array(tracks[0..<3])
+        }
+        else {
+            self.tracks = tracks
+        }
+    }
+    
+    enum CategoryType: String {
+        case track = "노래"
+        case album = "앨범"
+        case artist = "아티스트"
+    }
+    var body: some View {
+        VStack {
+            HStack {
+                Text(type.rawValue)
+                    .modifier(Title1())
+                Spacer()
+            }
+            ForEach(tracks) { track in
+                TrackCellView(track: track)
+            }
+        }
+    }
+}
+
+struct SearchAfterCategoryView_Previews: PreviewProvider {
+    static var previews: some View {
+        SearchAfterCategoryView(type: .album, tracks: TestData.playlist.tracks!)
+    }
+}

--- a/iOS/MiniVibe/MiniVibe/Scenes/Search/SearchAfterView.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/Search/SearchAfterView.swift
@@ -1,5 +1,5 @@
 //
-//  SearchAfterCategoriesView.swift
+//  SearchAfterView.swift
 //  MiniVibe
 //
 //  Created by 류연수 on 2020/12/02.
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct SearchAfterCategoriesView: View {
+struct SearchAfterView: View {
     private let tracks: [Track]?
     private let albums: [Album]?
     private let artists: [Artist]?
@@ -41,8 +41,8 @@ struct SearchAfterCategoriesView: View {
     }
 }
 
-struct SearchAfterCategoriesView_Previews: PreviewProvider {
+struct SearchAfterView_Previews: PreviewProvider {
     static var previews: some View {
-        SearchAfterCategoriesView(tracks: TestData.playlist.tracks, albums: nil, artists: nil)
+        SearchAfterView(tracks: TestData.playlist.tracks, albums: nil, artists: nil)
     }
 }


### PR DESCRIPTION
>한줄 요약

## 구현내용

### 화면
<img width="295" alt="스크린샷 2020-12-02 오전 3 03 41" src="https://user-images.githubusercontent.com/60538517/100779595-f571ce80-344b-11eb-8f59-0dd43767354b.png">

### 학습 내용(optional)
어떤 기술써서 어떻게 했다. 에 대한 기술 설명

## 논의사항
뷰 재활용을 어떤식으로 할지 이야기해보면 좋을 것 같아요❗️
앨범과 아티스트 셀 뷰의 경우 현재 트랙셀과 유사한데 이를 어떻게 재활용할지 고민해보면 좋을 것 같습니다.
거기다 현재 SearchAfterCategoryView는 `Track` 배열을 가지고 있는데 `Artist`와 `Album` 자료구조는 어떻게 묶어서 뷰를 재활용할지도 이야기 해보면 좋을 것 같습니다.