### PR TITLE
[iOS] 비동기 네트워킹을 통해 Image 뷰 생성

### DIFF
--- a/iOS/MiniVibe/MiniVibe.xcodeproj/project.pbxproj
+++ b/iOS/MiniVibe/MiniVibe.xcodeproj/project.pbxproj
@@ -19,6 +19,9 @@
 		515D26922575FAFF00B542BF /* ChartView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 515D26912575FAFF00B542BF /* ChartView.swift */; };
 		5181EA802570A0DC0077A727 /* NowPlayingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5181EA7F2570A0DA0077A727 /* NowPlayingView.swift */; };
 		5181EA882570A0E70077A727 /* PlayerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5181EA872570A0E70077A727 /* PlayerViewModel.swift */; };
+		5188C3F2257715D6001601E6 /* ActivityIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5188C3F1257715D6001601E6 /* ActivityIndicatorView.swift */; };
+		5188C3F725772ECC001601E6 /* TemporaryImageCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5188C3F625772ECC001601E6 /* TemporaryImageCache.swift */; };
+		5188C3FC25773123001601E6 /* ImageCacheKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5188C3FB25773123001601E6 /* ImageCacheKey.swift */; };
 		51BBBD7425763375009A6852 /* RequestBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51BBBD7325763375009A6852 /* RequestBuilder.swift */; };
 		51BBBD7D25763398009A6852 /* URLBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51BBBD7C25763398009A6852 /* URLBuilder.swift */; };
 		51BBBD85257662E1009A6852 /* PlaylistViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51BBBD84257662E1009A6852 /* PlaylistViewModel.swift */; };
@@ -30,6 +33,8 @@
 		51D6C6EF2572220300EF1B26 /* Image+accesoryModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51D6C6EE2572220300EF1B26 /* Image+accesoryModifier.swift */; };
 		51D6C6F82572418800EF1B26 /* PlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51D6C6F72572418800EF1B26 /* PlayerView.swift */; };
 		51D6C7032572725500EF1B26 /* BlurView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51D6C7022572725500EF1B26 /* BlurView.swift */; };
+		51E4E254257712AF00553E6E /* ImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51E4E253257712AE00553E6E /* ImageLoader.swift */; };
+		51E4E25C257712E300553E6E /* AsyncImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51E4E25B257712E300553E6E /* AsyncImage.swift */; };
 		51EED2DF256F7E3C00DB32CB /* CategoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51EED2D9256F7E3C00DB32CB /* CategoryView.swift */; };
 		51EED2E0256F7E3C00DB32CB /* CategoryCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51EED2DA256F7E3C00DB32CB /* CategoryCell.swift */; };
 		51EED2E1256F7E3C00DB32CB /* CategoryHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51EED2DB256F7E3C00DB32CB /* CategoryHeaderView.swift */; };
@@ -102,6 +107,9 @@
 		515D26912575FAFF00B542BF /* ChartView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartView.swift; sourceTree = "<group>"; };
 		5181EA7F2570A0DA0077A727 /* NowPlayingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NowPlayingView.swift; sourceTree = "<group>"; };
 		5181EA872570A0E70077A727 /* PlayerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerViewModel.swift; sourceTree = "<group>"; };
+		5188C3F1257715D6001601E6 /* ActivityIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityIndicatorView.swift; sourceTree = "<group>"; };
+		5188C3F625772ECC001601E6 /* TemporaryImageCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemporaryImageCache.swift; sourceTree = "<group>"; };
+		5188C3FB25773123001601E6 /* ImageCacheKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCacheKey.swift; sourceTree = "<group>"; };
 		51BBBD7325763375009A6852 /* RequestBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestBuilder.swift; sourceTree = "<group>"; };
 		51BBBD7C25763398009A6852 /* URLBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLBuilder.swift; sourceTree = "<group>"; };
 		51BBBD84257662E1009A6852 /* PlaylistViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaylistViewModel.swift; sourceTree = "<group>"; };
@@ -113,6 +121,8 @@
 		51D6C6EE2572220300EF1B26 /* Image+accesoryModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Image+accesoryModifier.swift"; sourceTree = "<group>"; };
 		51D6C6F72572418800EF1B26 /* PlayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerView.swift; sourceTree = "<group>"; };
 		51D6C7022572725500EF1B26 /* BlurView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlurView.swift; sourceTree = "<group>"; };
+		51E4E253257712AE00553E6E /* ImageLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageLoader.swift; sourceTree = "<group>"; };
+		51E4E25B257712E300553E6E /* AsyncImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncImage.swift; sourceTree = "<group>"; };
 		51EED2D9256F7E3C00DB32CB /* CategoryView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CategoryView.swift; sourceTree = "<group>"; };
 		51EED2DA256F7E3C00DB32CB /* CategoryCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CategoryCell.swift; sourceTree = "<group>"; };
 		51EED2DB256F7E3C00DB32CB /* CategoryHeaderView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CategoryHeaderView.swift; sourceTree = "<group>"; };
@@ -243,6 +253,18 @@
 			path = Player;
 			sourceTree = "<group>";
 		};
+		51E4E2522577127400553E6E /* Image */ = {
+			isa = PBXGroup;
+			children = (
+				51E4E25B257712E300553E6E /* AsyncImage.swift */,
+				51E4E253257712AE00553E6E /* ImageLoader.swift */,
+				5188C3F625772ECC001601E6 /* TemporaryImageCache.swift */,
+				5188C3FB25773123001601E6 /* ImageCacheKey.swift */,
+				5188C3F1257715D6001601E6 /* ActivityIndicatorView.swift */,
+			);
+			path = Image;
+			sourceTree = "<group>";
+		};
 		51EED2D8256F7E3C00DB32CB /* Today */ = {
 			isa = PBXGroup;
 			children = (
@@ -364,6 +386,7 @@
 				CF93D7D7256E8FBF005A71CF /* Extension */,
 				CFCFC5C0256E2A75004200C4 /* ViewModifier */,
 				CF05F8A72567E7AD008080D7 /* MiniVibeApp.swift */,
+				51E4E2522577127400553E6E /* Image */,
 				515D26742575224A00B542BF /* TestData.swift */,
 				515D26622575220B00B542BF /* Models */,
 				CF05F8AB2567E7B0008080D7 /* Assets.xcassets */,
@@ -568,15 +591,19 @@
 			files = (
 				CF05F8B42567E7B0008080D7 /* MiniVibe.xcdatamodeld in Sources */,
 				CF93D7D9256E9009005A71CF /* Sequence+indexed.swift in Sources */,
+				51E4E254257712AF00553E6E /* ImageLoader.swift in Sources */,
+				5188C3F725772ECC001601E6 /* TemporaryImageCache.swift in Sources */,
 				CF8286A2256BA5BA00D68373 /* ThumbnailCellView.swift in Sources */,
 				515D26752575224A00B542BF /* TestData.swift in Sources */,
 				515D266E2575220B00B542BF /* Artist.swift in Sources */,
 				CF93D7CB256E703D005A71CF /* ThumbnailRouter.swift in Sources */,
 				CF5E005B257241E80048F019 /* TrackListButtonView.swift in Sources */,
 				51BBBD7425763375009A6852 /* RequestBuilder.swift in Sources */,
+				51E4E25C257712E300553E6E /* AsyncImage.swift in Sources */,
 				CF6E5DC025755CCC00BE7503 /* RectangleCellView.swift in Sources */,
 				CF93D7C6256E6FED005A71CF /* RouterProtocol.swift in Sources */,
 				CF93D7AE256E31FB005A71CF /* ThumbnailListView.swift in Sources */,
+				5188C3FC25773123001601E6 /* ImageCacheKey.swift in Sources */,
 				CFCFC5C2256E2AA5004200C4 /* FontStyle.swift in Sources */,
 				CF93D7BE256E660D005A71CF /* NavigationBarStyle.swift in Sources */,
 				CF6E5DCE2575688800BE7503 /* RectangleCellInfoView.swift in Sources */,
@@ -611,6 +638,7 @@
 				515D266F2575220B00B542BF /* Playlist.swift in Sources */,
 				515D266D2575220B00B542BF /* User.swift in Sources */,
 				CF5E007A2572669E0048F019 /* PlaylistView.swift in Sources */,
+				5188C3F2257715D6001601E6 /* ActivityIndicatorView.swift in Sources */,
 				51EED2E4256F7E3C00DB32CB /* CategoryCellView.swift in Sources */,
 				51D6C7032572725500EF1B26 /* BlurView.swift in Sources */,
 				CF6E5DE325756E6300BE7503 /* GenreListView.swift in Sources */,

--- a/iOS/MiniVibe/MiniVibe/Common/Image/ActivityIndicatorView.swift
+++ b/iOS/MiniVibe/MiniVibe/Common/Image/ActivityIndicatorView.swift
@@ -1,0 +1,43 @@
+//
+//  ActivityIndicatorView.swift
+//  MiniVibe
+//
+//  Created by 강병민 on 2020/12/02.
+//
+
+import SwiftUI
+
+struct ActivityIndicatorView: View {
+    let style = StrokeStyle(lineWidth: 4, lineCap: .round)
+    @State var animate = false
+    let color1 = Color.gray
+    let color2 = Color.gray.opacity(0.5)
+    
+    var body: some View {
+        ZStack {
+            Circle()
+                .trim(from: 0, to: 0.2)
+                .stroke(AngularGradient(gradient: .init(colors: [color1, color2]), center: .center),
+                        style: style)
+                .rotationEffect(Angle(degrees: animate ? 360 : 0))
+                .animation(Animation.linear(duration: 0.7).repeatForever(autoreverses: false))
+            Circle()
+                .trim(from: 0.5, to: 0.7)
+                .stroke(AngularGradient(gradient: .init(colors: [color1, color2]), center: .center),
+                        style: style)
+                .rotationEffect(Angle(degrees: animate ? 360 : 0))
+                .animation(Animation.linear(duration: 0.7).repeatForever(autoreverses: false))
+        }
+        .onAppear(){
+            self.animate.toggle()
+        }
+
+    }
+}
+
+struct ActivityIndicatorView_Previews: PreviewProvider {
+    static var previews: some View {
+        ActivityIndicatorView()
+            .frame(width: /*@START_MENU_TOKEN@*/100/*@END_MENU_TOKEN@*/, height: /*@START_MENU_TOKEN@*/100/*@END_MENU_TOKEN@*/, alignment: /*@START_MENU_TOKEN@*/.center/*@END_MENU_TOKEN@*/)
+    }
+}

--- a/iOS/MiniVibe/MiniVibe/Common/Image/AsyncImage.swift
+++ b/iOS/MiniVibe/MiniVibe/Common/Image/AsyncImage.swift
@@ -1,0 +1,40 @@
+//
+//  AsyncImage.swift
+//  MiniVibe
+//
+//  Created by 강병민 on 2020/12/02.
+//
+
+import SwiftUI
+
+struct AsyncImage: View {
+    @StateObject private var loader: ImageLoader
+    let url: URL?
+    
+    init(url: URL?) {
+        _loader = StateObject(wrappedValue: ImageLoader(cache: Environment(\.imageCache).wrappedValue))
+        self.url = url
+    }
+    
+    var body: some View {
+        content
+            .onAppear{
+                loader.load(url: url)
+            }
+    }
+    
+    private var content: some View {
+        Group {
+            if let image = loader.image {
+                Image(uiImage: image)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                
+            } else {
+                ActivityIndicatorView()
+                    .padding()
+            }
+        }
+    }
+    
+}

--- a/iOS/MiniVibe/MiniVibe/Common/Image/ImageCacheKey.swift
+++ b/iOS/MiniVibe/MiniVibe/Common/Image/ImageCacheKey.swift
@@ -1,0 +1,20 @@
+//
+//  ImageCacheKey.swift
+//  MiniVibe
+//
+//  Created by 강병민 on 2020/12/02.
+//
+
+import Foundation
+import SwiftUI
+
+struct ImageCacheKey: EnvironmentKey {
+    static let defaultValue: ImageCache = TemporaryImageCache()
+}
+
+extension EnvironmentValues {
+    var imageCache: ImageCache {
+        get { self[ImageCacheKey.self] }
+        set { self[ImageCacheKey.self] = newValue }
+    }
+}

--- a/iOS/MiniVibe/MiniVibe/Common/Image/ImageLoader.swift
+++ b/iOS/MiniVibe/MiniVibe/Common/Image/ImageLoader.swift
@@ -1,0 +1,67 @@
+//
+//  ImageLoader.swift
+//  MiniVibe
+//
+//  Created by 강병민 on 2020/12/02.
+//
+
+import Foundation
+import Combine
+import SwiftUI
+
+class ImageLoader: ObservableObject {
+    @Published var image: UIImage?
+    private var cache: ImageCache?
+    private var cancellable: AnyCancellable?
+    private static let imageProcessingQueue = DispatchQueue(label: "image-processing")
+    private(set) var isLoading = false
+
+    init(cache: ImageCache? = nil) {
+        self.cache = cache
+    }
+
+    deinit {
+        cancel()
+    }
+
+    func load(url: URL?) {
+        print("load \(url?.absoluteString)")
+        guard !isLoading else { return }
+        guard let url = url else {
+            self.image = UIImage(named: "logo")
+            return
+        }
+
+        if let image = cache?[url] {
+            self.image = image
+            return
+        }
+        
+        cancellable = URLSession.shared.dataTaskPublisher(for: url)
+            .subscribe(on: Self.imageProcessingQueue)
+            .map { UIImage(data: $0.data) }
+            .replaceError(with: nil)
+            .handleEvents(receiveSubscription: { [weak self] _ in self?.onStart() },
+                          receiveOutput: { [weak self] in self?.cache($0, url: url) },
+                          receiveCompletion: { [weak self] _ in self?.onFinish() },
+                          receiveCancel: { [weak self] in self?.onFinish() })
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] in self?.image = $0 }
+    }
+    
+    private func cache(_ image: UIImage?, url: URL) {
+        image.map { cache?[url] = $0 }
+    }
+
+    func cancel() {
+        cancellable?.cancel()
+    }
+    
+    private func onStart() {
+        isLoading = true
+    }
+    
+    private func onFinish() {
+        isLoading = false
+    }
+}

--- a/iOS/MiniVibe/MiniVibe/Common/Image/TemporaryImageCache.swift
+++ b/iOS/MiniVibe/MiniVibe/Common/Image/TemporaryImageCache.swift
@@ -1,0 +1,22 @@
+//
+//  TemporaryImageCache.swift
+//  MiniVibe
+//
+//  Created by 강병민 on 2020/12/02.
+//
+
+import Foundation
+import SwiftUI
+
+protocol ImageCache {
+    subscript(_ url: URL) -> UIImage? { get set }
+}
+
+struct TemporaryImageCache: ImageCache {
+    private let cache = NSCache<NSURL, UIImage>()
+    
+    subscript(_ key: URL) -> UIImage? {
+        get { cache.object(forKey: key as NSURL) }
+        set { newValue == nil ? cache.removeObject(forKey: key as NSURL) : cache.setObject(newValue!, forKey: key as NSURL) }
+    }
+}

--- a/iOS/MiniVibe/MiniVibe/Scenes/NowPlaying/NowPlayingView.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/NowPlaying/NowPlayingView.swift
@@ -17,7 +17,7 @@ struct NowPlayingView: View {
             Button(action: {
                 self.showMediaPlayer.toggle()
             }, label: {
-                TrackInfoView(title: viewModel.currentTrack.trackName, artist: viewModel.currentTrack.artists.first?.name ?? "")
+                TrackInfoView(title: viewModel.trackName, artist: viewModel.artist, coverURLString: viewModel.currentTrack.album.cover)
                     .padding(.all, 9)
             }).sheet(isPresented: $showMediaPlayer, content: {
                 PlayerView(viewModel: viewModel, showMediaPlayer: $showMediaPlayer)

--- a/iOS/MiniVibe/MiniVibe/Scenes/Player/PlayerView.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/Player/PlayerView.swift
@@ -25,7 +25,6 @@ struct PlayerView: View {
                 //TODO: 밑에 재생 queue에 있는 노래 목록 보여주기
             }
             .frame(height: geometry.size.height)
-
         }
     }
 }
@@ -35,13 +34,13 @@ struct PlayerInfoView: View {
     
     var body: some View {
         VStack(spacing: 40) {
-            Image(track.trackName)
-                .fitModifier()
+            AsyncImage(url: URL(string: track.album.cover ?? ""))
+                .padding()
             HStack {
                 VStack (alignment: .leading){
                     Text(track.trackName)
                         .modifier(Title2())
-                    Text(track.trackName)
+                    Text(track.album.name)
                         .modifier(Description2())
                 }
                 Spacer()
@@ -89,7 +88,6 @@ struct PlayerControlView: View {
                 })
                 .accentColor(.primary)
             }
-            .frame(width: .infinity)
             HStack {
                 Spacer()
                 Button(action: {

--- a/iOS/MiniVibe/MiniVibe/Scenes/Player/PlayerViewModel.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/Player/PlayerViewModel.swift
@@ -8,8 +8,25 @@
 import Foundation
 
 class PlayerViewModel: ObservableObject {
-    @Published var currentTrack = TestData.playlist.tracks!.first!
+    @Published var currentTrack = Track(id: 37,
+                                        trackName: "Dynamite (Instrumental)",
+                                        albumTrackNumber: 2,
+                                        albumID: 8,
+                                        album: Album(id: 8,
+                                                     name: "Dynamite",
+                                                     description: "방탄",
+                                                     cover: "https://musicmeta-phinf.pstatic.net/album/004/820/4820425.jpg?type=r360Fll&v=20200918130108"),
+                                        artists: [Artist(id: 3, name: "방탄소년단", cover: nil)])
     @Published var queue = [Track]()
+    var trackName: String {
+        get { currentTrack.trackName }
+    }
+    var artist: String {
+        get { currentTrack.artists.first?.name ?? "" }
+    }
+    var coverURLString: String? {
+        get { currentTrack.album.cover }
+    }
     
     func updateWith(track: Track) {
         currentTrack = track

--- a/iOS/MiniVibe/MiniVibe/Scenes/Playlist/ThumbnailListView.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/Playlist/ThumbnailListView.swift
@@ -21,7 +21,7 @@ struct ThumbnailListView: View {
     var body: some View {
         List (viewModel.thumbnails.indexed(), id: \.1.id) { index, thumbnail in
             NavigationLink(
-                destination: router.getDestination(id: id)
+                destination: router.getDestination(id: thumbnail.id)
             ) {
                 ThumbnailCellView(thumbnail: viewModel.thumbnails[index])
             }

--- a/iOS/MiniVibe/MiniVibe/Scenes/TrackList/TrackCellView.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/TrackList/TrackCellView.swift
@@ -19,7 +19,7 @@ struct TrackCellView: View {
             Button(action: {
                 nowPlayingViewModel.updateWith(track: track)
             }, label: {
-                TrackInfoView(title: track.trackName, artist: track.artists.first?.name ?? "")
+                TrackInfoView(title: track.trackName, artist: track.artists.first?.name ?? "", coverURLString: track.album.cover)
             })
             HStack(spacing: 20) {
                 Heart(isFavorite: $isFavorite, toggleFavorite: didToggleFavorite)
@@ -62,15 +62,13 @@ struct Ellipsis: View {
 struct TrackInfoView: View {
     let title: String
     let artist: String
+    let coverURLString: String?
     
     var body: some View {
         HStack {
-            Image(title)
-                .resizable()
-                .aspectRatio(contentMode: .fit)
+            AsyncImage(url: URL(string: coverURLString ?? ""))
                 .frame(width: 44, height: 44, alignment: .center)
                 .padding(.vertical, 2)
-//                .padding(.horizontal, 10)
             VStack(alignment: .leading) {
                 Text(title)
                     .modifier(Title2())


### PR DESCRIPTION
서버에서 받은 urlString이 nil일때는 앱 로고를 표시하고
![image](https://user-images.githubusercontent.com/64558078/100837948-e5420980-34b4-11eb-8d10-90a47b5ec7ba.png)


서버에서 받고 있을때는 activity indication를 표시하며
![image](https://user-images.githubusercontent.com/64558078/100837827-ae6bf380-34b4-11eb-8742-5ea4a0b156d3.png)

 정상적으로 이미지가 로드가 될때 해당 앨범아트를 표시하게 했습니다
![image](https://user-images.githubusercontent.com/64558078/100837992-00ad1480-34b5-11eb-8348-555088508d4e.png)


캐싱은 우선 NSCache를 이용했습니다 (나중에 coredata로 바꿀수도 있을 것 같아요)

