### PR TITLE
[iOS] Player 화면 layout 수정

### DIFF
--- a/iOS/MiniVibe/MiniVibe.xcodeproj/project.pbxproj
+++ b/iOS/MiniVibe/MiniVibe.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		51BBBD7D25763398009A6852 /* URLBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51BBBD7C25763398009A6852 /* URLBuilder.swift */; };
 		51BBBD85257662E1009A6852 /* PlaylistViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51BBBD84257662E1009A6852 /* PlaylistViewModel.swift */; };
 		51BBBD9025766A9E009A6852 /* ErrorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51BBBD8F25766A9E009A6852 /* ErrorView.swift */; };
+		51BE9E3925777BF300CE41A6 /* Rectangle+Modifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51BE9E3825777BF300CE41A6 /* Rectangle+Modifier.swift */; };
 		51BEB332256F3C8600FB2876 /* DJStation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51BEB32F256F3C8600FB2876 /* DJStation.swift */; };
 		51BEB333256F3C8600FB2876 /* DJStationListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51BEB330256F3C8600FB2876 /* DJStationListViewModel.swift */; };
 		51BEB334256F3C8600FB2876 /* DJStationListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51BEB331256F3C8600FB2876 /* DJStationListView.swift */; };
@@ -117,6 +118,7 @@
 		51BBBD7C25763398009A6852 /* URLBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLBuilder.swift; sourceTree = "<group>"; };
 		51BBBD84257662E1009A6852 /* PlaylistViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaylistViewModel.swift; sourceTree = "<group>"; };
 		51BBBD8F25766A9E009A6852 /* ErrorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorView.swift; sourceTree = "<group>"; };
+		51BE9E3825777BF300CE41A6 /* Rectangle+Modifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Rectangle+Modifier.swift"; sourceTree = "<group>"; };
 		51BEB32F256F3C8600FB2876 /* DJStation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DJStation.swift; sourceTree = "<group>"; };
 		51BEB330256F3C8600FB2876 /* DJStationListViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DJStationListViewModel.swift; sourceTree = "<group>"; };
 		51BEB331256F3C8600FB2876 /* DJStationListView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DJStationListView.swift; sourceTree = "<group>"; };
@@ -447,6 +449,7 @@
 			children = (
 				CF93D7D8256E9009005A71CF /* Sequence+indexed.swift */,
 				51D6C6EE2572220300EF1B26 /* Image+accesoryModifier.swift */,
+				51BE9E3825777BF300CE41A6 /* Rectangle+Modifier.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -622,6 +625,7 @@
 				CF6E5DB62575501F00BE7503 /* SearchView.swift in Sources */,
 				CF2D94B0256F825B00D0A66B /* TrackListView.swift in Sources */,
 				CF5C214A25741952007C7229 /* TodayRouter.swift in Sources */,
+				51BE9E3925777BF300CE41A6 /* Rectangle+Modifier.swift in Sources */,
 				CF5C214F25741BEE007C7229 /* CategoryRouter.swift in Sources */,
 				51BEB333256F3C8600FB2876 /* DJStationListViewModel.swift in Sources */,
 				51D6C6EF2572220300EF1B26 /* Image+accesoryModifier.swift in Sources */,

--- a/iOS/MiniVibe/MiniVibe/Common/Extension/Rectangle+Modifier.swift
+++ b/iOS/MiniVibe/MiniVibe/Common/Extension/Rectangle+Modifier.swift
@@ -1,0 +1,17 @@
+//
+//  Rectangle+Modifier.swift
+//  MiniVibe
+//
+//  Created by 강병민 on 2020/12/02.
+//
+
+import SwiftUI
+
+extension Rectangle {
+    func clearBottom() -> some View {
+        self
+            .fill(Color.clear)
+            .frame(height: 50)
+            .listRowInsets(EdgeInsets())
+    }
+}

--- a/iOS/MiniVibe/MiniVibe/Scenes/NowPlaying/NowPlayingView.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/NowPlaying/NowPlayingView.swift
@@ -35,6 +35,7 @@ struct NowPlayingView: View {
             .padding(.horizontal, 20)
         }
         .background(BlurView())
+        .preferredColorScheme(.dark)
     }
 }
 

--- a/iOS/MiniVibe/MiniVibe/Scenes/Player/PlayerView.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/Player/PlayerView.swift
@@ -10,102 +10,38 @@ import SwiftUI
 struct PlayerView: View {
     @ObservedObject var viewModel : PlayerViewModel
     @Binding var showMediaPlayer: Bool
-
+    @State var timeDuration = Float(180)
+    
     var body: some View {
         GeometryReader { geometry in
             ScrollView(.vertical, showsIndicators: false) {
-                VStack() {
+                VStack(spacing: 10) {
                     PlayerHeaderView(showMediaPlayer: $showMediaPlayer)
-                    Spacer()
-                    PlayerInfoView(track: viewModel.currentTrack)
-                    Spacer()
+                    PlayerInfoView(track: viewModel.currentTrack, timeDuration: $timeDuration)
                     PlayerControlView(viewModel: viewModel)
                 }
+                .padding(.horizontal, 20)
+                .padding(.bottom, geometry.safeAreaInsets.bottom)
                 .frame(height: geometry.size.height)
-                //TODO: 밑에 재생 queue에 있는 노래 목록 보여주기
-            }
-            .frame(height: geometry.size.height)
-        }
-    }
-}
 
-struct PlayerInfoView: View {
-    let track: Track
-    
-    var body: some View {
-        VStack(spacing: 40) {
-            AsyncImage(url: URL(string: track.album.cover ?? ""))
-                .padding()
-            HStack {
-                VStack (alignment: .leading){
-                    Text(track.trackName)
-                        .modifier(Title2())
-                    Text(track.album.name)
-                        .modifier(Description2())
+                LazyVGrid(columns: [GridItem(.flexible())]) {
+                    ForEach(viewModel.queue) { track    in                     TrackCellView(track: track)                    }
+                    Rectangle()
+                        .clearBottom()
                 }
-                Spacer()
-                Image(systemName: "ellipsis")
-                    .accesoryModifier(color: .gray, size: .medium)
+                .padding(.horizontal, 20)
+                
             }
-            .padding(.horizontal, 10)
+            .background(Color(UIColor.systemBackground))
+            .preferredColorScheme(.dark)
         }
+        .edgesIgnoringSafeArea(.bottom)
     }
-}
-
-struct PlayerControlView: View {
-    @ObservedObject var viewModel : PlayerViewModel
-    
-    var body: some View {
-        VStack {
-            HStack(spacing: 20) {
-                Button(action: {}, label: {
-                    Image(systemName: "repeat")
-                        .resizeToFit(padding: 15)
-                })
-                .accentColor(.primary)
-                Button(action: {}, label: {
-                    Image(systemName: "paperplane")
-                        .resizeToFit(padding: 5)
-                        .font(Font.title.weight(.light))
-                })
-                .accentColor(.primary)
-                Button(action: {}, label: {
-                    Image(systemName: "play")
-                        .resizeToFit(padding: 5)
-                        .font(Font.title.weight(.light))
-                })
-                .accentColor(.primary)
-
-                Button(action: {}, label: {
-                    Image(systemName: "heart")
-                        .resizeToFit(padding: 5)
-                })
-                .accentColor(.red)
-
-                Button(action: {}, label: {
-                    Image(systemName: "shuffle")
-                        .resizeToFit(padding: 15)
-                })
-                .accentColor(.primary)
-            }
-            HStack {
-                Spacer()
-                Button(action: {
-                    print(viewModel.queue)
-                }, label: {
-                    Image(systemName: "music.note.list")
-                        .accesoryModifier(color: .gray, size: .medium)
-                        .padding()
-                })
-            }
-        }
-    }
-    
 }
 
 struct PlayerHeaderView: View {
     @Binding var showMediaPlayer: Bool
-
+    
     var body: some View {
         HStack() {
             Image(systemName: "flame")
@@ -121,17 +57,112 @@ struct PlayerHeaderView: View {
                 
             })
         }
-        .padding()
     }
+}
+
+struct PlayerInfoView: View {
+    let track: Track
+    @Binding var timeDuration: Float
+    
+    var body: some View {
+        VStack(spacing: 40) {
+            AsyncImage(url: URL(string: track.album.cover ?? ""))
+                .padding()
+            HStack() {
+                VStack(alignment: .leading, spacing: 10){
+                    Text(track.trackName)
+                        .font(.system(size: 24, weight: .bold))
+                    Text(track.artists.first?.name ?? "")
+                        .font(.system(size: 18, weight: .light))
+                        .foregroundColor(.secondary)
+                }
+                Spacer()
+                Image(systemName: "ellipsis")
+                    .accesoryModifier(color: .gray, size: .medium)
+            }
+            Slider(value: $timeDuration)
+                .padding(.bottom, 20.0)
+                .accentColor(.red)
+        }
+    }
+}
+
+struct PlayerControlView: View {
+    @ObservedObject var viewModel : PlayerViewModel
+    
+    var body: some View {
+        VStack() {
+            HStack() {
+                Button(action: {}, label: {
+                    Image(systemName: "repeat")
+                        .accesoryModifier(color: .gray, size: .medium)
+                })
+                .accentColor(.primary)
+                Spacer()
+                Button(action: {}, label: {
+                    Image(systemName: "paperplane")
+                        .accesoryModifier(color: .gray, size: .large)
+                    //                        .font(Font.title.weight(.light))
+                })
+                .accentColor(.primary)
+                Spacer()
+                Button(action: {}, label: {
+                    Image(systemName: "play")
+                        .accesoryModifier(color: .primary, size: .large)
+                        .font(Font.title.weight(.light))
+                })
+                .accentColor(.primary)
+                Spacer()
+                
+                Button(action: {}, label: {
+                    Image(systemName: "heart")
+                        .accesoryModifier(color: .red, size: .large)
+                })
+                .accentColor(.red)
+                Spacer()
+                
+                Button(action: {}, label: {
+                    Image(systemName: "shuffle")
+                        .accesoryModifier(color: .gray, size: .medium)
+                })
+                .accentColor(.primary)
+                
+            }
+            .padding(.vertical, 10)
+            HStack(alignment: .bottom) {
+                Button(action: {
+                    print(viewModel.queue)
+                }, label: {
+                    Image(systemName: "airplayaudio")
+                        .accesoryModifier(color: .gray, size: .medium)
+                })
+                
+                Spacer()
+                Text("미리듣기 중")
+                    .foregroundColor(.red)
+                Spacer()
+                Button(action: {
+                    print(viewModel.queue)
+                }, label: {
+                    Image(systemName: "music.note.list")
+                        .accesoryModifier(color: .gray, size: .medium)
+                })
+            }
+            .padding(.top, 20)
+            .padding(.bottom, 10)
+        }
+    }
+    
 }
 
 struct PlayerView_Previews: PreviewProvider {
     static var previews: some View {
         Group {
             PlayerView(viewModel: PlayerViewModel(), showMediaPlayer: .constant(true))
+                .colorScheme(.dark)
             //작은 화면 프리뷰
-//            PlayerView(viewModel: PlayerViewModel(), showMediaPlayer: .constant(true))
-//                .previewDevice("iPhone 8")
+            PlayerView(viewModel: PlayerViewModel(), showMediaPlayer: .constant(true))
+                .previewDevice("iPhone 8")
         }
     }
 }

--- a/iOS/MiniVibe/MiniVibe/Scenes/Playlist/ThumbnailListView.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/Playlist/ThumbnailListView.swift
@@ -21,16 +21,22 @@ struct ThumbnailListView: View {
     var body: some View {
         guard let title = router.title() else { return AnyView(ErrorView()) }
         return AnyView(
-            List (viewModel.thumbnails.indexed(), id: \.1.id) { index, thumbnail in
-                NavigationLink(
-                    destination: router.getDestination(id: thumbnail.id)
-                ) {
-                    ThumbnailCellView(thumbnail: viewModel.thumbnails[index])
+            List{
+                ForEach(viewModel.thumbnails.indexed(), id: \.1.id) {
+                    _, thumbnail in
+                    NavigationLink(
+                        destination: router.getDestination(id: thumbnail.id)
+                    ) {
+                        ThumbnailCellView(thumbnail: thumbnail)
+                    }
                 }
+                Rectangle()
+                    .clearBottom()
             }.modifier(NavigationBarStyle(title: title))
             .onAppear() {
                 viewModel.fetch(type: router.routingStarter, id: id)
             }
+            
         )
     }
 }

--- a/iOS/MiniVibe/MiniVibe/Scenes/Today/TodayView.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/Today/TodayView.swift
@@ -22,6 +22,8 @@ struct TodayView: View {
                     )
                 }
                 .listRowInsets(EdgeInsets())
+                Rectangle()
+                    .clearBottom()
             }.listStyle(PlainListStyle())
             .navigationTitle("VIBE")
         }
@@ -30,9 +32,9 @@ struct TodayView: View {
     }
 }
 
-//struct TodayView_Previews: PreviewProvider {
-//    static var previews: some View {
-//        TodayView()
-//    }
-//}
-//
+struct TodayView_Previews: PreviewProvider {
+    static var previews: some View {
+        TodayView()
+    }
+}
+

--- a/iOS/MiniVibe/MiniVibe/Scenes/TrackList/TrackListView.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/TrackList/TrackListView.swift
@@ -27,6 +27,8 @@ struct TrackListView: View {
                 }
                 return cell
             }
+            Rectangle()
+                .clearBottom()
         }.onAppear() {
             viewModel.createTracks(tracks: tracks)
         }


### PR DESCRIPTION
>틀만 잡아놓았던 layout을 실제 vibe 앱에 비슷하도록 수정했습니다.

## 구현내용

### 화면(optional)
![image](https://user-images.githubusercontent.com/64558078/100867444-90ff4f80-34dd-11eb-91b3-47c14cf6c053.png)

### 논의사항
현재 slider를 기본 Slider에서 accent color만 바꿔놨습니다.
vibe 앱에 비슷하도록 만들어주기 위해서는 Custom으로 직접 구현해야해서 나중으로 미뤄놨습니다.