### PR TITLE
[iOS] 차트와 서치 뷰 네트워킹 연결

### DIFF
--- a/iOS/MiniVibe/MiniVibe.xcodeproj/project.pbxproj
+++ b/iOS/MiniVibe/MiniVibe.xcodeproj/project.pbxproj
@@ -82,6 +82,8 @@
 		CFCBC9442577866900439C3F /* MagazineViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFCBC9432577866900439C3F /* MagazineViewModel.swift */; };
 		CFCBC9522577BC9B00439C3F /* TrackHorizontalListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFCBC9512577BC9B00439C3F /* TrackHorizontalListView.swift */; };
 		CFCBC95A2577FB4A00439C3F /* TrackInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFCBC9592577FB4A00439C3F /* TrackInfoView.swift */; };
+		CFCBC9702578074200439C3F /* SearchAfterViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFCBC96F2578074200439C3F /* SearchAfterViewModel.swift */; };
+		CFCBC975257807F300439C3F /* Search.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFCBC974257807F300439C3F /* Search.swift */; };
 		CFCFC5C2256E2AA5004200C4 /* FontStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFCFC5C1256E2AA5004200C4 /* FontStyle.swift */; };
 /* End PBXBuildFile section */
 
@@ -184,6 +186,8 @@
 		CFCBC9432577866900439C3F /* MagazineViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MagazineViewModel.swift; sourceTree = "<group>"; };
 		CFCBC9512577BC9B00439C3F /* TrackHorizontalListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackHorizontalListView.swift; sourceTree = "<group>"; };
 		CFCBC9592577FB4A00439C3F /* TrackInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackInfoView.swift; sourceTree = "<group>"; };
+		CFCBC96F2578074200439C3F /* SearchAfterViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchAfterViewModel.swift; sourceTree = "<group>"; };
+		CFCBC974257807F300439C3F /* Search.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Search.swift; sourceTree = "<group>"; };
 		CFCFC5C1256E2AA5004200C4 /* FontStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontStyle.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -221,6 +225,7 @@
 				515D26672575220B00B542BF /* Artist.swift */,
 				515D26682575220B00B542BF /* Playlist.swift */,
 				514FDD8D25761F6800F6BF93 /* Magazine.swift */,
+				CFCBC974257807F300439C3F /* Search.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -357,6 +362,7 @@
 		CF2D94A9256F825B00D0A66B /* TrackList */ = {
 			isa = PBXGroup;
 			children = (
+				CFCBC9592577FB4A00439C3F /* TrackInfoView.swift */,
 				CF2D94AA256F825B00D0A66B /* TrackCellView.swift */,
 				CF2D94AC256F825B00D0A66B /* TrackListView.swift */,
 				515D26802575385B00B542BF /* TrackPageView.swift */,
@@ -365,7 +371,6 @@
 				CF5E005A257241E80048F019 /* TrackListButtonView.swift */,
 				CF5E006425724BA00048F019 /* TrackListHeaderView.swift */,
 				CFCBC9512577BC9B00439C3F /* TrackHorizontalListView.swift */,
-				CFCBC9592577FB4A00439C3F /* TrackInfoView.swift */,
 			);
 			path = TrackList;
 			sourceTree = "<group>";
@@ -437,6 +442,7 @@
 				CF6E5DE225756E6300BE7503 /* GenreListView.swift */,
 				CF3BDD622576AA6100FF768E /* SearchAfterCategoryView.swift */,
 				CF3BDD672576BAB500FF768E /* SearchAfterView.swift */,
+				CFCBC96F2578074200439C3F /* SearchAfterViewModel.swift */,
 			);
 			path = Search;
 			sourceTree = "<group>";
@@ -628,6 +634,7 @@
 				51E4E25C257712E300553E6E /* AsyncImage.swift in Sources */,
 				CF6E5DC025755CCC00BE7503 /* RectangleCellView.swift in Sources */,
 				CF93D7C6256E6FED005A71CF /* RouterProtocol.swift in Sources */,
+				CFCBC975257807F300439C3F /* Search.swift in Sources */,
 				CF93D7AE256E31FB005A71CF /* ThumbnailListView.swift in Sources */,
 				5188C3FC25773123001601E6 /* ImageCacheKey.swift in Sources */,
 				CFCFC5C2256E2AA5004200C4 /* FontStyle.swift in Sources */,
@@ -676,6 +683,7 @@
 				51BBBD7D25763398009A6852 /* URLBuilder.swift in Sources */,
 				51BBBD85257662E1009A6852 /* PlaylistViewModel.swift in Sources */,
 				CF6E5DDB25756BAC00BE7503 /* GenreCellView.swift in Sources */,
+				CFCBC9702578074200439C3F /* SearchAfterViewModel.swift in Sources */,
 				CF05F8A82567E7AD008080D7 /* MiniVibeApp.swift in Sources */,
 				CF2D94B1256F825B00D0A66B /* TrackListViewModel.swift in Sources */,
 				5181EA802570A0DC0077A727 /* NowPlayingView.swift in Sources */,

--- a/iOS/MiniVibe/MiniVibe.xcodeproj/project.pbxproj
+++ b/iOS/MiniVibe/MiniVibe.xcodeproj/project.pbxproj
@@ -81,6 +81,7 @@
 		CFCBC9392577852900439C3F /* MiniVibeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFCBC9382577852900439C3F /* MiniVibeViewModel.swift */; };
 		CFCBC9442577866900439C3F /* MagazineViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFCBC9432577866900439C3F /* MagazineViewModel.swift */; };
 		CFCBC9522577BC9B00439C3F /* TrackHorizontalListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFCBC9512577BC9B00439C3F /* TrackHorizontalListView.swift */; };
+		CFCBC95A2577FB4A00439C3F /* TrackInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFCBC9592577FB4A00439C3F /* TrackInfoView.swift */; };
 		CFCFC5C2256E2AA5004200C4 /* FontStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFCFC5C1256E2AA5004200C4 /* FontStyle.swift */; };
 /* End PBXBuildFile section */
 
@@ -182,6 +183,7 @@
 		CFCBC9382577852900439C3F /* MiniVibeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiniVibeViewModel.swift; sourceTree = "<group>"; };
 		CFCBC9432577866900439C3F /* MagazineViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MagazineViewModel.swift; sourceTree = "<group>"; };
 		CFCBC9512577BC9B00439C3F /* TrackHorizontalListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackHorizontalListView.swift; sourceTree = "<group>"; };
+		CFCBC9592577FB4A00439C3F /* TrackInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackInfoView.swift; sourceTree = "<group>"; };
 		CFCFC5C1256E2AA5004200C4 /* FontStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontStyle.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -363,6 +365,7 @@
 				CF5E005A257241E80048F019 /* TrackListButtonView.swift */,
 				CF5E006425724BA00048F019 /* TrackListHeaderView.swift */,
 				CFCBC9512577BC9B00439C3F /* TrackHorizontalListView.swift */,
+				CFCBC9592577FB4A00439C3F /* TrackInfoView.swift */,
 			);
 			path = TrackList;
 			sourceTree = "<group>";
@@ -644,6 +647,7 @@
 				CFCBC92E257764B200439C3F /* MiniVibeType.swift in Sources */,
 				515D266C2575220B00B542BF /* Album.swift in Sources */,
 				51BBBD9025766A9E009A6852 /* ErrorView.swift in Sources */,
+				CFCBC95A2577FB4A00439C3F /* TrackInfoView.swift in Sources */,
 				515D26812575385B00B542BF /* TrackPageView.swift in Sources */,
 				CF5E00602572441D0048F019 /* ButtonStyle.swift in Sources */,
 				515D266A2575220B00B542BF /* Track.swift in Sources */,

--- a/iOS/MiniVibe/MiniVibe.xcodeproj/project.pbxproj
+++ b/iOS/MiniVibe/MiniVibe.xcodeproj/project.pbxproj
@@ -80,6 +80,7 @@
 		CFCBC92E257764B200439C3F /* MiniVibeType.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFCBC92D257764B200439C3F /* MiniVibeType.swift */; };
 		CFCBC9392577852900439C3F /* MiniVibeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFCBC9382577852900439C3F /* MiniVibeViewModel.swift */; };
 		CFCBC9442577866900439C3F /* MagazineViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFCBC9432577866900439C3F /* MagazineViewModel.swift */; };
+		CFCBC9522577BC9B00439C3F /* TrackHorizontalListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFCBC9512577BC9B00439C3F /* TrackHorizontalListView.swift */; };
 		CFCFC5C2256E2AA5004200C4 /* FontStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFCFC5C1256E2AA5004200C4 /* FontStyle.swift */; };
 /* End PBXBuildFile section */
 
@@ -180,6 +181,7 @@
 		CFCBC92D257764B200439C3F /* MiniVibeType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiniVibeType.swift; sourceTree = "<group>"; };
 		CFCBC9382577852900439C3F /* MiniVibeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiniVibeViewModel.swift; sourceTree = "<group>"; };
 		CFCBC9432577866900439C3F /* MagazineViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MagazineViewModel.swift; sourceTree = "<group>"; };
+		CFCBC9512577BC9B00439C3F /* TrackHorizontalListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackHorizontalListView.swift; sourceTree = "<group>"; };
 		CFCFC5C1256E2AA5004200C4 /* FontStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontStyle.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -360,6 +362,7 @@
 				CF2D94AD256F825B00D0A66B /* TrackListViewModel.swift */,
 				CF5E005A257241E80048F019 /* TrackListButtonView.swift */,
 				CF5E006425724BA00048F019 /* TrackListHeaderView.swift */,
+				CFCBC9512577BC9B00439C3F /* TrackHorizontalListView.swift */,
 			);
 			path = TrackList;
 			sourceTree = "<group>";
@@ -664,6 +667,7 @@
 				5188C3F2257715D6001601E6 /* ActivityIndicatorView.swift in Sources */,
 				51EED2E4256F7E3C00DB32CB /* CategoryCellView.swift in Sources */,
 				51D6C7032572725500EF1B26 /* BlurView.swift in Sources */,
+				CFCBC9522577BC9B00439C3F /* TrackHorizontalListView.swift in Sources */,
 				CF6E5DE325756E6300BE7503 /* GenreListView.swift in Sources */,
 				51BBBD7D25763398009A6852 /* URLBuilder.swift in Sources */,
 				51BBBD85257662E1009A6852 /* PlaylistViewModel.swift in Sources */,

--- a/iOS/MiniVibe/MiniVibe/Common/Models/Search.swift
+++ b/iOS/MiniVibe/MiniVibe/Common/Models/Search.swift
@@ -1,0 +1,20 @@
+//
+//  Search.swift
+//  MiniVibe
+//
+//  Created by 류연수 on 2020/12/03.
+//
+
+import Foundation
+
+struct Search: Codable {
+    let albums: [Album]?
+    let tracks: [Track]?
+    let artists: [Artist]?
+    
+    enum CodingKeys: String, CodingKey {
+        case albums = "Albums"
+        case tracks = "Tracks"
+        case artists = "Artists"
+    }
+}

--- a/iOS/MiniVibe/MiniVibe/Common/Models/Track.swift
+++ b/iOS/MiniVibe/MiniVibe/Common/Models/Track.swift
@@ -11,8 +11,8 @@ struct Track: Codable, Identifiable {
     let id: Int
     let trackName: String
     let albumTrackNumber, albumID: Int
-    let album: Album
-    let artists: [Artist]
+    let album: Album?
+    let artists: [Artist]?
 
     enum CodingKeys: String, CodingKey {
         case id, trackName, albumTrackNumber

--- a/iOS/MiniVibe/MiniVibe/Common/Network/MiniVibeViewModel.swift
+++ b/iOS/MiniVibe/MiniVibe/Common/Network/MiniVibeViewModel.swift
@@ -14,7 +14,7 @@ class MiniVibeViewModel {
     private var cancellabes = Set<AnyCancellable>()
     
     func internalFetch(endPoint: MiniVibeType, id: Int? = nil, filterQuery: String? = nil, limitQuery: String? = nil,  completion: @escaping (Data) -> Void) {
-        let url = URLBuilder(pathType: .api, endPoint: endPoint, id: id, filterQuery: nil, limitQuery: nil).create()
+        let url = URLBuilder(pathType: .api, endPoint: endPoint, id: id, filterQuery: filterQuery, limitQuery: limitQuery).create()
         
         guard let request = RequestBuilder(url: url,
                                            body: nil,

--- a/iOS/MiniVibe/MiniVibe/Common/Network/URLBuilder.swift
+++ b/iOS/MiniVibe/MiniVibe/Common/Network/URLBuilder.swift
@@ -45,7 +45,6 @@ struct URLBuilder {
         if queryItems.isEmpty == false {
             urlComponents?.queryItems = queryItems
         }
-        
         return urlComponents?.url
     }
 }

--- a/iOS/MiniVibe/MiniVibe/Scenes/Chart/ChartView.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/Chart/ChartView.swift
@@ -8,30 +8,25 @@
 import SwiftUI
 
 struct ChartView: View {
-    private let layout = [GridItem(.flexible())]
+    let tracks: [Track]
     
     var body: some View {
-        ScrollView {
-            LazyVGrid(columns: layout,
-                      spacing: 20) {
-                Section(header:
-                            NavigationLink(
-                                destination: PlaylistView(playlistID: 1)
-                            ,
-                            label: {
-                                CategoryHeaderView(title: "오늘 TOP 100")
-                            }))
-                {
-//                    TrackPageView(id: 1)
+        NavigationView {
+            ScrollView {
+                LazyVGrid(columns: [ GridItem(.flexible()) ]) {
+                    TrackHorizontalListView(tracks: tracks)
+                    
                 }
-                      }
-        }.padding()
+            }
+            .padding()
+            .navigationTitle("차트")
+        }
     }
     
 }
 struct ChartView_Previews: PreviewProvider {
     static var previews: some View {
-        ChartView()
+        ChartView(tracks: TestData.playlist.tracks!)
     }
 }
 

--- a/iOS/MiniVibe/MiniVibe/Scenes/Chart/ChartView.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/Chart/ChartView.swift
@@ -8,25 +8,35 @@
 import SwiftUI
 
 struct ChartView: View {
-    let tracks: [Track]
+    @StateObject private var viewModel = PlaylistViewModel()
+    
+    private let playlistID: Int
+    private let layout = [GridItem(.flexible())]
+    
+    init(playlistID: Int) {
+        self.playlistID = playlistID
+    }
     
     var body: some View {
         NavigationView {
             ScrollView {
-                LazyVGrid(columns: [ GridItem(.flexible()) ]) {
-                    TrackHorizontalListView(tracks: tracks)
-                    
+                LazyVGrid(columns: layout) {
+                    if let tracks = viewModel.playlist?.tracks {
+                        TrackHorizontalListView(tracks: tracks)
+                    }
                 }
             }
             .padding()
             .navigationTitle("차트")
+        }.onAppear {
+            viewModel.fetch(id: playlistID)
         }
     }
     
 }
 struct ChartView_Previews: PreviewProvider {
     static var previews: some View {
-        ChartView(tracks: TestData.playlist.tracks!)
+        ChartView(playlistID: 18)
     }
 }
 

--- a/iOS/MiniVibe/MiniVibe/Scenes/NowPlaying/NowPlayingView.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/NowPlaying/NowPlayingView.swift
@@ -17,7 +17,7 @@ struct NowPlayingView: View {
             Button(action: {
                 self.showMediaPlayer.toggle()
             }, label: {
-                TrackInfoView(title: viewModel.trackName, artist: viewModel.artist, coverURLString: viewModel.currentTrack.album.cover)
+                TrackInfoView(title: viewModel.trackName, artist: viewModel.artist, coverURLString: viewModel.currentTrack.album?.cover)
                     .padding(.all, 9)
             }).sheet(isPresented: $showMediaPlayer, content: {
                 PlayerView(viewModel: viewModel, showMediaPlayer: $showMediaPlayer)

--- a/iOS/MiniVibe/MiniVibe/Scenes/Player/PlayerView.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/Player/PlayerView.swift
@@ -25,7 +25,7 @@ struct PlayerView: View {
                 .frame(height: geometry.size.height)
 
                 LazyVGrid(columns: [GridItem(.flexible())]) {
-                    ForEach(viewModel.queue) { track    in                     TrackCellView(track: track)                    }
+                    ForEach(viewModel.queue) { track    in                     TrackCellView(hasAccessory: true, track: track)                    }
                     Rectangle()
                         .clearBottom()
                 }
@@ -66,13 +66,13 @@ struct PlayerInfoView: View {
     
     var body: some View {
         VStack(spacing: 40) {
-            AsyncImage(url: URL(string: track.album.cover ?? ""))
+            AsyncImage(url: URL(string: track.album?.cover ?? ""))
                 .padding()
             HStack() {
                 VStack(alignment: .leading, spacing: 10){
                     Text(track.trackName)
                         .font(.system(size: 24, weight: .bold))
-                    Text(track.artists.first?.name ?? "")
+                    Text(track.artists?.first?.name ?? "")
                         .font(.system(size: 18, weight: .light))
                         .foregroundColor(.secondary)
                 }

--- a/iOS/MiniVibe/MiniVibe/Scenes/Player/PlayerViewModel.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/Player/PlayerViewModel.swift
@@ -22,10 +22,10 @@ class PlayerViewModel: ObservableObject {
         get { currentTrack.trackName }
     }
     var artist: String {
-        get { currentTrack.artists.first?.name ?? "" }
+        get { currentTrack.artists?.first?.name ?? "" }
     }
     var coverURLString: String? {
-        get { currentTrack.album.cover }
+        get { currentTrack.album?.cover }
     }
     
     func updateWith(track: Track) {

--- a/iOS/MiniVibe/MiniVibe/Scenes/Playlist/PlaylistView.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/Playlist/PlaylistView.swift
@@ -22,7 +22,6 @@ struct PlaylistView: View {
               let tracks = playlist.tracks else { return AnyView(EmptyView().onAppear(perform: {
                 viewModel.fetch(id: playlistID)
             }))
-             
         }
         
         return AnyView(

--- a/iOS/MiniVibe/MiniVibe/Scenes/Search/GenreCellView.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/Search/GenreCellView.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 struct GenreCellView: View {
+    let title: String
+    
     var body: some View {
         Button(action: {
             // action
@@ -16,7 +18,7 @@ struct GenreCellView: View {
                 RoundedRectangle(cornerRadius: 25, style: .continuous)
                     .frame(width: 6, height: 30)
                     .foregroundColor(.blue)
-                Text("PLAY")
+                Text(title)
                     .modifier(Title2())
                 Spacer()
             }.modifier(TrackListButtonStyle())
@@ -26,6 +28,6 @@ struct GenreCellView: View {
 
 struct GenreCellView_Previews: PreviewProvider {
     static var previews: some View {
-        GenreCellView()
+        GenreCellView(title: "Title")
     }
 }

--- a/iOS/MiniVibe/MiniVibe/Scenes/Search/GenreListView.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/Search/GenreListView.swift
@@ -16,16 +16,16 @@ struct GenreListView: View {
     var body: some View {
         LazyVGrid(columns: layout,
                   spacing: 10) {
-            GenreCellView()
-            GenreCellView()
-            GenreCellView()
-            GenreCellView()
-            GenreCellView()
-            GenreCellView()
-            GenreCellView()
-            GenreCellView()
-            GenreCellView()
-            GenreCellView()
+            GenreCellView(title: "국내 댄스")
+            GenreCellView(title: "국내 발라드")
+            GenreCellView(title: "국내 락/메탈")
+            GenreCellView(title: "국내 알앤비/소울")
+            GenreCellView(title: "국내 Pop")
+            GenreCellView(title: "국내 K-Pop")
+            GenreCellView(title: "국내 일레트로닉")
+            GenreCellView(title: "국내 힙합")
+            GenreCellView(title: "국내 재즈")
+            GenreCellView(title: "국내 인디")
         }
     }
 }

--- a/iOS/MiniVibe/MiniVibe/Scenes/Search/SearchAfterCategoryView.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/Search/SearchAfterCategoryView.swift
@@ -30,7 +30,7 @@ struct SearchAfterCategoryView: View {
                 Spacer()
             }
             ForEach(tracks.prefix(maxCountOfTracks)) { track in
-                TrackCellView(track: track)
+                TrackCellView(hasAccessory: true, track: track)
             }
         }
     }

--- a/iOS/MiniVibe/MiniVibe/Scenes/Search/SearchAfterView.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/Search/SearchAfterView.swift
@@ -8,14 +8,11 @@
 import SwiftUI
 
 struct SearchAfterView: View {
-    private let tracks: [Track]?
-    private let albums: [Album]?
-    private let artists: [Artist]?
+    private let searchText: String
+    @StateObject private var viewModel = SearchAfterViewModel()
     
-    init(tracks: [Track]?, albums: [Album]?, artists: [Artist]?) {
-        self.tracks = tracks
-        self.albums = albums
-        self.artists = artists
+    init(searchText: String) {
+        self.searchText = searchText
     }
     
     var body: some View {
@@ -23,26 +20,27 @@ struct SearchAfterView: View {
             LazyVGrid(columns: [GridItem(.flexible())],
                       spacing: 40,
                       pinnedViews: [.sectionHeaders]) {
-                Section(header: SearchBarView(text: .constant(""))) {
-                    if let tracks = tracks {
+                Section(header: SearchBarView(defaultText: searchText)) {
+                    if let tracks = viewModel.tracks {
                         SearchAfterCategoryView(type: .track, tracks: tracks)
-                        SearchAfterCategoryView(type: .album, tracks: tracks)
-                        SearchAfterCategoryView(type: .artist, tracks: tracks)
                     }
-            //        if let albums = albums {
-            //            SearchAfterCategoryView(type: .album, tracks: albums)
-            //        }
-            //        if let artists = artists {
-            //            SearchAfterCategoryView(type: .artist, tracks: artists)
-            //        }
+//                    if let albums = viewModel.albums {
+//                        SearchAfterCategoryView(type: .album, tracks: albums)
+//                    }
+//                    if let artists = viewModel.artists {
+//                        SearchAfterCategoryView(type: .artist, tracks: artists)
+//                    }
                 }
             }
         }.padding()
+        .onAppear {
+            viewModel.fetch(searchText: searchText)
+        }
     }
 }
 
 struct SearchAfterView_Previews: PreviewProvider {
     static var previews: some View {
-        SearchAfterView(tracks: TestData.playlist.tracks, albums: nil, artists: nil)
+        SearchAfterView(searchText: "우기")
     }
 }

--- a/iOS/MiniVibe/MiniVibe/Scenes/Search/SearchAfterViewModel.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/Search/SearchAfterViewModel.swift
@@ -1,0 +1,27 @@
+//
+//  SearchAfterViewModel.swift
+//  MiniVibe
+//
+//  Created by 류연수 on 2020/12/03.
+//
+
+import SwiftUI
+
+class SearchAfterViewModel: MiniVibeViewModel, ObservableObject {
+    
+    @Published var tracks: [Track]?
+    @Published var albums: [Album]?
+    @Published var artists: [Artist]?
+    
+    func fetch(searchText: String) {
+        internalFetch(endPoint: .search, filterQuery: searchText) { [weak self] data in
+            if let decodedData = try? JSONDecoder().decode(Search.self, from: data) {
+                DispatchQueue.main.async {
+                    self?.tracks = decodedData.tracks
+                    self?.albums = decodedData.albums
+                    self?.artists = decodedData.artists
+                }
+            }
+        }
+    }
+}

--- a/iOS/MiniVibe/MiniVibe/Scenes/Search/SearchBarView.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/Search/SearchBarView.swift
@@ -8,39 +8,49 @@
 import SwiftUI
 
 struct SearchBarView: View {
-    @Binding var text: String
+    @State private var text: String = ""
     @State private var isEditing = false
+    @State private var isPushed = false
+    
+    init(defaultText: String) {
+        self.text = defaultText
+    }
     
     var body: some View {
         HStack {
-            TextField("검색어를 입력해 주세요.", text: $text)
-                .padding(9)
-                .padding(.horizontal, 27)
-                .background(Color(.systemGray6))
-                .cornerRadius(8)
-//                .padding(.horizontal, 10)
-                .onTapGesture {
-                    self.isEditing = true
-                }
-                .overlay(
-                    HStack {
-                        Image(systemName: "magnifyingglass")
+            TextField("검색어를 입력해 주세요.", text: $text) { isEditing in
+                self.isEditing = isEditing
+            } onCommit: {
+                isPushed = true
+            }.sheet(isPresented: $isPushed) {
+                SearchAfterView(searchText: text)
+            }
+            .padding(9)
+            .padding(.horizontal, 27)
+            .background(Color(.systemGray6))
+            .cornerRadius(8)
+            //                .padding(.horizontal, 10)
+            //                .onTapGesture {
+            //                    self.isEditing = true
+            //                }
+            .overlay(
+                HStack {
+                    Image(systemName: "magnifyingglass")
+                        .foregroundColor(.gray)
+                        .frame(minWidth: 0, maxWidth: .infinity, alignment: .leading)
+                        .padding(.leading, 12)
+                    if !isEditing {
+                        Image(systemName: "music.note")
                             .foregroundColor(.gray)
-                            .frame(minWidth: 0, maxWidth: .infinity, alignment: .leading)
-                            .padding(.leading, 12)
-                        if !isEditing {
-                            Image(systemName: "music.note")
-                                .foregroundColor(.gray)
-                                .padding(.trailing, 12)
-                        }
+                            .padding(.trailing, 12)
                     }
-                )
+                }
+            )
             
             if isEditing {
                 Button(action: {
-                    self.isEditing = false
-                    self.text = ""
-                    
+                    isEditing = false
+                    text = ""
                 }) {
                     Text("취소")
                 }
@@ -54,6 +64,6 @@ struct SearchBarView: View {
 
 struct SearchBarView_Previews: PreviewProvider {
     static var previews: some View {
-        SearchBarView(text: .constant(""))
+        SearchBarView(defaultText: "")
     }
 }

--- a/iOS/MiniVibe/MiniVibe/Scenes/Search/SearchView.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/Search/SearchView.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 struct SearchView: View {
+//    @State private var searchText = ""
+    
     private let layout = [GridItem(.flexible())]
     
     var body: some View {
@@ -15,7 +17,7 @@ struct SearchView: View {
             LazyVGrid(columns: layout,
                       spacing: 20,
                       pinnedViews: [.sectionHeaders]) {
-                Section(header: SearchBarView(text: .constant(""))) {
+                Section(header: SearchBarView(defaultText: "")) {
                     RectangleListView()
                     HStack {
                         Text("장르")

--- a/iOS/MiniVibe/MiniVibe/Scenes/TabBar/TabBarView.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/TabBar/TabBarView.swift
@@ -19,7 +19,7 @@ struct TabBarView: View {
                     Text("투데이")
                 }
                 .overlay(NowPlayingView(viewModel: playerViewModel), alignment: .bottom)
-            ChartView(tracks: TestData.playlist.tracks!)
+            ChartView(playlistID: 18)
                 .tabItem {
                     Image(systemName: "chart.bar.fill")
                     Text("차트")

--- a/iOS/MiniVibe/MiniVibe/Scenes/TabBar/TabBarView.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/TabBar/TabBarView.swift
@@ -19,7 +19,7 @@ struct TabBarView: View {
                     Text("투데이")
                 }
                 .overlay(NowPlayingView(viewModel: playerViewModel), alignment: .bottom)
-            ChartView()
+            ChartView(tracks: TestData.playlist.tracks!)
                 .tabItem {
                     Image(systemName: "chart.bar.fill")
                     Text("차트")

--- a/iOS/MiniVibe/MiniVibe/Scenes/TrackList/TrackCellView.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/TrackList/TrackCellView.swift
@@ -59,28 +59,6 @@ struct Ellipsis: View {
     }
 }
 
-struct TrackInfoView: View {
-    let title: String
-    let artist: String
-    let coverURLString: String?
-    
-    var body: some View {
-        HStack {
-            AsyncImage(url: URL(string: coverURLString ?? ""))
-                .frame(width: 44, height: 44, alignment: .center)
-                .padding(.vertical, 2)
-            VStack(alignment: .leading) {
-                Text(title)
-                    .modifier(Title2())
-                Text(artist)
-                    .modifier(Description2())
-            }
-            Spacer()
-        }
-    }
-}
-
-
 struct TrackCellView_Previews: PreviewProvider {
     
     static var previews: some View {

--- a/iOS/MiniVibe/MiniVibe/Scenes/TrackList/TrackCellView.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/TrackList/TrackCellView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct TrackCellView: View {
-    
+    let hasAccessory: Bool
     let track: Track
     var didToggleFavorite: (() -> Void)?
     @EnvironmentObject var nowPlayingViewModel: PlayerViewModel
@@ -19,12 +19,15 @@ struct TrackCellView: View {
             Button(action: {
                 nowPlayingViewModel.updateWith(track: track)
             }, label: {
-                TrackInfoView(title: track.trackName, artist: track.artists.first?.name ?? "", coverURLString: track.album.cover)
+                TrackInfoView(title: track.trackName, artist: track.artists?.first?.name ?? "", coverURLString: track.album?.cover)
             })
-            HStack(spacing: 20) {
-                Heart(isFavorite: $isFavorite, toggleFavorite: didToggleFavorite)
-                Ellipsis()
+            if hasAccessory {
+                HStack(spacing: 20) {
+                    Heart(isFavorite: $isFavorite, toggleFavorite: didToggleFavorite)
+                    Ellipsis()
+                }
             }
+            
         }
     }
 }
@@ -65,7 +68,7 @@ struct TrackCellView_Previews: PreviewProvider {
         let testTrack1 = TestData.playlist.tracks!.first!
         
         Group {
-            TrackCellView(track: testTrack1)
+            TrackCellView(hasAccessory: true, track: testTrack1)
             
         }
         .previewLayout(.sizeThatFits)

--- a/iOS/MiniVibe/MiniVibe/Scenes/TrackList/TrackGroupView.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/TrackList/TrackGroupView.swift
@@ -12,7 +12,7 @@ struct TrackGroupView: View {
     var body: some View {
         VStack {
             ForEach(trackGroup.tracks) { track in
-                TrackCellView(track: track)
+                TrackCellView(hasAccessory: true, track: track)
             }
         }
         .onAppear{

--- a/iOS/MiniVibe/MiniVibe/Scenes/TrackList/TrackHorizontalListView.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/TrackList/TrackHorizontalListView.swift
@@ -27,10 +27,8 @@ struct TrackHorizontalListView: View {
                 ScrollView(.horizontal, showsIndicators: false) {
                     LazyHGrid(rows: layout,
                               spacing: 20) {
-                        ForEach(tracks) { track -> TrackInfoView in
-                            TrackInfoView(title: track.trackName,
-                                          artist: track.artists.first?.name ?? "",
-                                          coverURLString: track.album.cover)
+                        ForEach(tracks) { track -> TrackCellView in
+                            TrackCellView(hasAccessory: false, track: track)
                         }.frame(width: UIScreen.main.bounds.width - 64)
                     }
                 }

--- a/iOS/MiniVibe/MiniVibe/Scenes/TrackList/TrackHorizontalListView.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/TrackList/TrackHorizontalListView.swift
@@ -1,0 +1,46 @@
+//
+//  TrackHorizontalListView.swift
+//  MiniVibe
+//
+//  Created by 류연수 on 2020/12/02.
+//
+
+import SwiftUI
+
+struct TrackHorizontalListView: View {
+    let tracks: [Track]
+    private let layout = [
+        GridItem(.fixed(60)),
+        GridItem(.fixed(60)),
+        GridItem(.fixed(60)),
+        GridItem(.fixed(60)),
+        GridItem(.fixed(60))
+    ]
+    
+    var body: some View {
+        Group {
+            VStack {
+                NavigationLink(destination: PlaylistView(playlistID: 1)) {
+                    CategoryHeaderView(title: "오늘 TOP 100")
+                        .foregroundColor(.primary)
+                }
+                ScrollView(.horizontal, showsIndicators: false) {
+                    LazyHGrid(rows: layout,
+                              spacing: 20) {
+                        ForEach(tracks) { track -> TrackInfoView in
+                            TrackInfoView(title: track.trackName,
+                                          artist: track.artists.first?.name ?? "",
+                                          coverURLString: track.album.cover)
+                        }.frame(width: UIScreen.main.bounds.width - 64)
+                    }
+                }
+            }
+        }
+    }
+}
+
+struct TrackHorizontalListView_Previews: PreviewProvider {
+    static var previews: some View {
+        TrackHorizontalListView(tracks: TestData.playlist.tracks!)
+    }
+}

--- a/iOS/MiniVibe/MiniVibe/Scenes/TrackList/TrackInfoView.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/TrackList/TrackInfoView.swift
@@ -1,0 +1,35 @@
+//
+//  TrackInfoView.swift
+//  MiniVibe
+//
+//  Created by 류연수 on 2020/12/03.
+//
+
+import SwiftUI
+
+struct TrackInfoView: View {
+    let title: String
+    let artist: String
+    let coverURLString: String?
+    
+    var body: some View {
+        HStack {
+            AsyncImage(url: URL(string: coverURLString ?? ""))
+                .frame(width: 44, height: 44, alignment: .center)
+                .padding(.vertical, 2)
+            VStack(alignment: .leading) {
+                Text(title)
+                    .modifier(Title2())
+                Text(artist)
+                    .modifier(Description2())
+            }
+            Spacer()
+        }
+    }
+}
+
+struct TrackInfoView_Previews: PreviewProvider {
+    static var previews: some View {
+        TrackInfoView()
+    }
+}

--- a/iOS/MiniVibe/MiniVibe/Scenes/TrackList/TrackInfoView.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/TrackList/TrackInfoView.swift
@@ -30,6 +30,6 @@ struct TrackInfoView: View {
 
 struct TrackInfoView_Previews: PreviewProvider {
     static var previews: some View {
-        TrackInfoView()
+        TrackInfoView(title: "title", artist: "artist", coverURLString: nil)
     }
 }

--- a/iOS/MiniVibe/MiniVibe/Scenes/TrackList/TrackListView.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/TrackList/TrackListView.swift
@@ -21,7 +21,7 @@ struct TrackListView: View {
     var body: some View {
         LazyVGrid(columns: layout) {
             ForEach(viewModel.tracks) { track -> TrackCellView in
-                var cell = TrackCellView(track: track)
+                var cell = TrackCellView(hasAccessory: true, track: track)
                 cell.didToggleFavorite = {
                     viewModel.toggleIsFavorite(for: track.id)
                 }


### PR DESCRIPTION
>한줄 요약

## 구현내용

### 화면
<img width="286" alt="chartPage" src="https://user-images.githubusercontent.com/60538517/100917874-15bc8e80-351b-11eb-9864-c123fae11fd5.gif">

<img width="286" alt="searchPage" src="https://user-images.githubusercontent.com/60538517/100917858-10f7da80-351b-11eb-96d3-4c38402bb354.gif">

### 학습 내용
매우졸려서 내일 설명

## 논의사항
- [ ] 현재 검색했을 때 새로운 모달이 뜨는데 내일 새로운 뷰가 뜨도록 변경
- [ ] 앨범과 아티스트 다 가져오는데 뷰 재활용 문제때문에 보여주지는 않고 있음
