### PR TITLE
[FE] feat: Slidebar translateX range 설정

### DIFF
--- a/frontend/components/Button/SlidebarButton/index.tsx
+++ b/frontend/components/Button/SlidebarButton/index.tsx
@@ -4,9 +4,10 @@ import { NextArrowSvg, PreviousArrowSvg } from "../../../utils/svg";
 
 interface SlideButtonProps {
   onClick?: () => void;
+  hide?: boolean;
 }
 
-const NextButton = styled.div`
+const NextButton = styled.div<SlideButtonProps>`
   position: absolute;
   width: 40px;
   height: 40px;
@@ -15,13 +16,14 @@ const NextButton = styled.div`
   background-color: #fff;
   border-radius: 50%;
   z-index: 10000;
+  display: ${({ hide }) => (hide ? "none" : "block")};
   & svg {
     width: 20px;
     height: 20px;
     padding: 10px;
   }
 `;
-const PreviousButton = styled.div`
+const PreviousButton = styled.div<SlideButtonProps>`
   position: absolute;
   width: 40px;
   height: 40px;
@@ -30,6 +32,7 @@ const PreviousButton = styled.div`
   background-color: #fff;
   border-radius: 50%;
   z-index: 10000;
+  display: ${({ hide }) => (hide ? "none" : "block")};
   & svg {
     width: 20px;
     height: 20px;
@@ -37,17 +40,23 @@ const PreviousButton = styled.div`
   }
 `;
 
-export const SliderNextButtton: React.FC<SlideButtonProps> = ({ onClick }: SlideButtonProps) => {
+export const SliderNextButtton: React.FC<SlideButtonProps> = ({
+  onClick,
+  hide,
+}: SlideButtonProps) => {
   return (
-    <NextButton onClick={onClick}>
+    <NextButton onClick={onClick} hide={hide}>
       <NextArrowSvg />
     </NextButton>
   );
 };
 
-export const SliderPreviousButton: React.FC<SlideButtonProps> = ({ onClick }: SlideButtonProps) => {
+export const SliderPreviousButton: React.FC<SlideButtonProps> = ({
+  onClick,
+  hide,
+}: SlideButtonProps) => {
   return (
-    <PreviousButton onClick={onClick}>
+    <PreviousButton onClick={onClick} hide={hide}>
       <PreviousArrowSvg />
     </PreviousButton>
   );

--- a/frontend/components/Slidebar/index.tsx
+++ b/frontend/components/Slidebar/index.tsx
@@ -53,15 +53,19 @@ const Slidebar: React.FC<SlidebarProps> = ({
 }: SlidebarProps) => {
   const [currentTranslateX, setCurrentTranslateX] = useState(0);
   const [slidePixels, setSlidePixels] = useState(0);
+  const [nextHide, setNextHide] = useState(false);
+  const [previousHide, setPreviousHide] = useState(true);
   const currentSlideRef = useRef<HTMLUListElement>(null);
 
   const onPreviousClicked = () => {
     const newTranslateX = currentTranslateX + slidePixels;
     if (newTranslateX > 0) {
       setCurrentTranslateX(0);
+      setPreviousHide(true);
       return;
     }
     setCurrentTranslateX(newTranslateX);
+    setNextHide(false);
   };
 
   const onNextClicked = () => {
@@ -73,9 +77,11 @@ const Slidebar: React.FC<SlidebarProps> = ({
       const newTranslateX = currentTranslateX - slidePixels;
       if (newTranslateX < -containerWidth) {
         setCurrentTranslateX(-containerWidth + cardMargin);
+        setNextHide(true);
         return;
       }
       setCurrentTranslateX(newTranslateX);
+      setPreviousHide(false);
     }
   };
 
@@ -93,11 +99,8 @@ const Slidebar: React.FC<SlidebarProps> = ({
 
   useEffect(() => {
     calculatePixels();
-  }, []);
-
-  useEffect(() => {
     window.addEventListener("resize", calculatePixels);
-  }, [currentTranslateX]);
+  }, []);
 
   return (
     <StyledSlidebar varient={varient}>
@@ -111,8 +114,8 @@ const Slidebar: React.FC<SlidebarProps> = ({
             <Card varient={varient} dataType={dataType} rawData={value} />
           ))}
         </SlideContent>
-        <SliderPreviousButton onClick={onPreviousClicked} />
-        <SliderNextButtton onClick={onNextClicked} />
+        <SliderPreviousButton onClick={onPreviousClicked} hide={previousHide} />
+        <SliderNextButtton onClick={onNextClicked} hide={nextHide} />
       </SlideContainer>
     </StyledSlidebar>
   );

--- a/frontend/components/Slidebar/index.tsx
+++ b/frontend/components/Slidebar/index.tsx
@@ -12,6 +12,10 @@ export interface SlidebarProps {
   data?: any;
 }
 
+interface TranslateProps {
+  currentTranslateX?: number;
+}
+
 const StyledSlidebar = styled.div<SlidebarProps>`
   display: flex;
   flex-direction: column;
@@ -30,12 +34,14 @@ const SlideContainer = styled.div`
   position: relative;
 `;
 
-const SlideContent = styled.ul`
+const SlideContent = styled.ul<TranslateProps>`
   display: flex;
   & > li:first-child {
     margin: 0;
   }
   padding-inline-start: 0;
+  transition: all 0.6s ease-in-out;
+  transform: ${({ currentTranslateX }) => `translateX(${currentTranslateX}px)`};
 `;
 
 const Slidebar: React.FC<SlidebarProps> = ({
@@ -45,18 +51,35 @@ const Slidebar: React.FC<SlidebarProps> = ({
   titleLink,
   data,
 }: SlidebarProps) => {
-  const [currentSlide, setCurrentSlide] = useState(0);
+  const [currentTranslateX, setCurrentTranslateX] = useState(0);
+  const [slidePixels, setSlidePixels] = useState(0);
   const currentSlideRef = useRef<HTMLUListElement>(null);
 
   const onPreviousClicked = () => {
-    if (currentSlide === 0) return;
-    setCurrentSlide(currentSlide - 1);
-  };
-  const onNextClicked = () => {
-    setCurrentSlide(currentSlide + 1);
+    const newTranslateX = currentTranslateX + slidePixels;
+    if (newTranslateX > 0) {
+      setCurrentTranslateX(0);
+      return;
+    }
+    setCurrentTranslateX(newTranslateX);
   };
 
-  useEffect(() => {
+  const onNextClicked = () => {
+    const { current } = currentSlideRef;
+    if (current !== null) {
+      const cardStyles = window.getComputedStyle(current.firstElementChild?.nextSibling);
+      const cardMargin = Number(cardStyles.marginLeft.slice(0, -2));
+      const containerWidth = Number(window.getComputedStyle(current).width.slice(0, -2));
+      const newTranslateX = currentTranslateX - slidePixels;
+      if (newTranslateX < -containerWidth) {
+        setCurrentTranslateX(-containerWidth + cardMargin);
+        return;
+      }
+      setCurrentTranslateX(newTranslateX);
+    }
+  };
+
+  const calculatePixels = () => {
     const { current } = currentSlideRef;
     if (current !== null) {
       const containerWidth = Number(window.getComputedStyle(current).width.slice(0, -2));
@@ -64,21 +87,26 @@ const Slidebar: React.FC<SlidebarProps> = ({
       const cardWidth = Number(cardStyles.width.slice(0, -2));
       const cardMargin = Number(cardStyles.marginLeft.slice(0, -2));
       const viewedCards = Math.floor(containerWidth / cardWidth);
-      const slidePixels = (cardWidth + cardMargin) * viewedCards;
-      current.style.transition = "all 0.5s ease-in-out";
-      current.style.transform = `translateX(-${slidePixels * currentSlide}px)`;
+      setSlidePixels((cardWidth + cardMargin) * viewedCards);
     }
-  }, [currentSlide]);
+  };
+
+  useEffect(() => {
+    calculatePixels();
+  }, []);
+
+  useEffect(() => {
+    window.addEventListener("resize", calculatePixels);
+  }, [currentTranslateX]);
 
   return (
     <StyledSlidebar varient={varient}>
       <a href={titleLink}>
         {title}
-        {currentSlide}
         {titleLink ? <NextArrowSvg /> : ""}
       </a>
       <SlideContainer>
-        <SlideContent ref={currentSlideRef}>
+        <SlideContent currentTranslateX={currentTranslateX} ref={currentSlideRef}>
           {data?.map((value: any) => (
             <Card varient={varient} dataType={dataType} rawData={value} />
           ))}

--- a/frontend/components/Slidebar/index.tsx
+++ b/frontend/components/Slidebar/index.tsx
@@ -59,8 +59,14 @@ const Slidebar: React.FC<SlidebarProps> = ({
   useEffect(() => {
     const { current } = currentSlideRef;
     if (current !== null) {
+      const containerWidth = Number(window.getComputedStyle(current).width.slice(0, -2));
+      const cardStyles = window.getComputedStyle(current.firstElementChild?.nextSibling);
+      const cardWidth = Number(cardStyles.width.slice(0, -2));
+      const cardMargin = Number(cardStyles.marginLeft.slice(0, -2));
+      const viewedCards = Math.floor(containerWidth / cardWidth);
+      const slidePixels = (cardWidth + cardMargin) * viewedCards;
       current.style.transition = "all 0.5s ease-in-out";
-      current.style.transform = `translateX(-${currentSlide}00%)`;
+      current.style.transform = `translateX(-${slidePixels * currentSlide}px)`;
     }
   }, [currentSlide]);
 

--- a/frontend/pages/today/index.tsx
+++ b/frontend/pages/today/index.tsx
@@ -4,10 +4,6 @@ import HotMagCard from "../../components/HotMagCard";
 import Card from "../../components/Card";
 import Slidebar from "../../components/Slidebar";
 
-const TempSlide = styled.div`
-  display: flex;
-`;
-
 const IndexPage = memo(({ Magazines, News, Playlists }: any) => {
   return (
     <>


### PR DESCRIPTION


>Slidebar 스크롤 이동 거리 설정

## 구현내용
container width, card width 얻어서 현재 보이는 card 개수 계산 
  useRef로 DOM element 가져와서 window.getComputedStyle로 width px값 가져와서 사용
현재 보이는 card들 바로 다음 card의 시작점에서 멈추도록 설정
  translateteX 적용
현재는 돌아오는 때에도 왼쪽 기준으로만 정지

## 논의사항
우측 버튼 기준으로 구현되어 잘 됨.
좌측 버튼을 눌러도 우측버튼 이동점 기준으로 이동.
원래 Vibe는 좌측 버튼 누르면 반대쪽 기준으로 이동
