### PR TITLE
Reachabililty 추가 /화면 이벤트 추가 / Today화면에 DJ Station 추가

### DIFF
--- a/iOS/MiniVibe/MiniVibe.xcodeproj/project.pbxproj
+++ b/iOS/MiniVibe/MiniVibe.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 52;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -35,6 +35,8 @@
 		51B82B17257DF0E600A005E8 /* PlayerInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51B82B16257DF0E600A005E8 /* PlayerInfoView.swift */; };
 		51B82B1C257DF0F100A005E8 /* PlayerControlView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51B82B1B257DF0F100A005E8 /* PlayerControlView.swift */; };
 		51B82B21257E00AC00A005E8 /* ToggleableImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51B82B20257E00AC00A005E8 /* ToggleableImage.swift */; };
+		51B82B2A257E5F5600A005E8 /* Reachability in Frameworks */ = {isa = PBXBuildFile; productRef = 51B82B29257E5F5600A005E8 /* Reachability */; };
+		51B82B30257E5FE000A005E8 /* ReachabilityObserverDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51B82B2F257E5FE000A005E8 /* ReachabilityObserverDelegate.swift */; };
 		51BBBD7425763375009A6852 /* RequestBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51BBBD7325763375009A6852 /* RequestBuilder.swift */; };
 		51BBBD7D25763398009A6852 /* URLBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51BBBD7C25763398009A6852 /* URLBuilder.swift */; };
 		51BBBD85257662E1009A6852 /* PlaylistViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51BBBD84257662E1009A6852 /* PlaylistViewModel.swift */; };
@@ -152,6 +154,7 @@
 		51B82B16257DF0E600A005E8 /* PlayerInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerInfoView.swift; sourceTree = "<group>"; };
 		51B82B1B257DF0F100A005E8 /* PlayerControlView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerControlView.swift; sourceTree = "<group>"; };
 		51B82B20257E00AC00A005E8 /* ToggleableImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToggleableImage.swift; sourceTree = "<group>"; };
+		51B82B2F257E5FE000A005E8 /* ReachabilityObserverDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReachabilityObserverDelegate.swift; sourceTree = "<group>"; };
 		51BBBD7325763375009A6852 /* RequestBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestBuilder.swift; sourceTree = "<group>"; };
 		51BBBD7C25763398009A6852 /* URLBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLBuilder.swift; sourceTree = "<group>"; };
 		51BBBD84257662E1009A6852 /* PlaylistViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaylistViewModel.swift; sourceTree = "<group>"; };
@@ -233,6 +236,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				339F5D98C64C2189DBB1B27E /* Pods_MiniVibe.framework in Frameworks */,
+				51B82B2A257E5F5600A005E8 /* Reachability in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -321,6 +325,14 @@
 				51B82B20257E00AC00A005E8 /* ToggleableImage.swift */,
 			);
 			path = SubViews;
+			sourceTree = "<group>";
+		};
+		51B82B2E257E5FCC00A005E8 /* Reachability */ = {
+			isa = PBXGroup;
+			children = (
+				51B82B2F257E5FE000A005E8 /* ReachabilityObserverDelegate.swift */,
+			);
+			path = Reachability;
 			sourceTree = "<group>";
 		};
 		51BEB32E256F3C8600FB2876 /* DJStation */ = {
@@ -564,6 +576,7 @@
 		CF6E5D902574E82400BE7503 /* Common */ = {
 			isa = PBXGroup;
 			children = (
+				51B82B2E257E5FCC00A005E8 /* Reachability */,
 				51B3D4A9257CFB25008025E5 /* Event */,
 				CF6E5D942574E8B500BE7503 /* Network */,
 				CFA2A447256FD1E700190A0B /* Router */,
@@ -664,6 +677,9 @@
 			dependencies = (
 			);
 			name = MiniVibe;
+			packageProductDependencies = (
+				51B82B29257E5F5600A005E8 /* Reachability */,
+			);
 			productName = MiniVibe;
 			productReference = CF05F8A42567E7AD008080D7 /* MiniVibe.app */;
 			productType = "com.apple.product-type.application";
@@ -737,6 +753,9 @@
 				Base,
 			);
 			mainGroup = CF05F89B2567E7AD008080D7;
+			packageReferences = (
+				51B82B28257E5F5500A005E8 /* XCRemoteSwiftPackageReference "Reachability" */,
+			);
 			productRefGroup = CF05F8A52567E7AD008080D7 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -902,6 +921,7 @@
 				CFCBC92E257764B200439C3F /* MiniVibeType.swift in Sources */,
 				515D266C2575220B00B542BF /* Album.swift in Sources */,
 				51BBBD9025766A9E009A6852 /* ErrorView.swift in Sources */,
+				51B82B30257E5FE000A005E8 /* ReachabilityObserverDelegate.swift in Sources */,
 				CFCBC95A2577FB4A00439C3F /* BasicRowCellView.swift in Sources */,
 				515D26812575385B00B542BF /* TrackPageView.swift in Sources */,
 				CF5E00602572441D0048F019 /* ButtonStyle.swift in Sources */,
@@ -1272,6 +1292,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		51B82B28257E5F5500A005E8 /* XCRemoteSwiftPackageReference "Reachability" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/ashleymills/Reachability.swift";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 5.1.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		51B82B29257E5F5600A005E8 /* Reachability */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 51B82B28257E5F5500A005E8 /* XCRemoteSwiftPackageReference "Reachability" */;
+			productName = Reachability;
+		};
+/* End XCSwiftPackageProductDependency section */
 
 /* Begin XCVersionGroup section */
 		CF05F8B22567E7B0008080D7 /* MiniVibe.xcdatamodeld */ = {

--- a/iOS/MiniVibe/MiniVibe.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/iOS/MiniVibe/MiniVibe.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "Reachability",
+        "repositoryURL": "https://github.com/ashleymills/Reachability.swift",
+        "state": {
+          "branch": null,
+          "revision": "c01bbdf2d633cf049ae1ed1a68a2020a8bda32e2",
+          "version": "5.1.0"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/iOS/MiniVibe/MiniVibe/Common/Event/AnalyticsEngine.swift
+++ b/iOS/MiniVibe/MiniVibe/Common/Event/AnalyticsEngine.swift
@@ -14,7 +14,18 @@ protocol AnalyticsEngine: class {
 class MockAnalyticsEngine: AnalyticsEngine {
 
     func sendAnalyticsEvent(named name: String, metadata: [String: String]) {
-        print("\(name)")
+        print("MockServer - \(name)")
+        metadata.forEach { key, value in
+            print("ㄴ \(key) : \(value)")
+        }
+    }
+    
+}
+
+class BackupAnalyticsEngine: AnalyticsEngine {
+
+    func sendAnalyticsEvent(named name: String, metadata: [String: String]) {
+        print("BACKUP - \(name)")
         metadata.forEach { key, value in
             print("ㄴ \(key) : \(value)")
         }

--- a/iOS/MiniVibe/MiniVibe/Common/Event/AnalyticsManager.swift
+++ b/iOS/MiniVibe/MiniVibe/Common/Event/AnalyticsManager.swift
@@ -8,13 +8,57 @@
 import Foundation
 
 class AnalyticsManager {
-    private let engine: AnalyticsEngine
-
+    private var currentEngine: AnalyticsEngine?
+    private let serverEngine: AnalyticsEngine
+    private let backupEngine = BackupAnalyticsEngine()
+    
     init(engine: AnalyticsEngine) {
-        self.engine = engine
+        self.serverEngine = engine
+        try? addReachabilityObserver()
+        setupEngine()
     }
-
+    
+    deinit {
+        removeReachabilityObserver()
+    }
+    
+    func setupEngine() {
+        switch getConnection() {
+        case .unavailable:
+            currentEngine = backupEngine
+            print("init engine: backup")
+        default:
+            currentEngine = serverEngine
+            print("init engine: server")
+        }
+    }
+    
     func log(_ event: AnalyticsEvent) {
-        engine.sendAnalyticsEvent(named: event.name, metadata: event.metadata)
+        guard let currentEngine = currentEngine else { return }
+        currentEngine.sendAnalyticsEvent(named: event.name, metadata: event.metadata)
     }
+    
+    func switchToServerEngine() {
+        //TODO: Core Data에 쌓인 이벤트 로그 서버에 보내기
+        currentEngine = serverEngine
+    }
+    
+    func switchToBackupEngine() {
+        currentEngine = backupEngine
+    }
+    
+}
+
+extension AnalyticsManager: ReachabilityObserverDelegate {
+    
+    func reachabilityChanged(_ isReachable: Bool) {
+        if isReachable {
+            print("switchToServerEngine")
+            switchToServerEngine()
+        } else {
+            print("switchToBackupEngine")
+            switchToBackupEngine()
+        }
+    }
+    
 }

--- a/iOS/MiniVibe/MiniVibe/Common/Event/AnalyticsManager.swift
+++ b/iOS/MiniVibe/MiniVibe/Common/Event/AnalyticsManager.swift
@@ -39,12 +39,18 @@ class AnalyticsManager {
     }
     
     func switchToServerEngine() {
-        //TODO: Core Data에 쌓인 이벤트 로그 서버에 보내기
-        currentEngine = serverEngine
+        if currentEngine !== serverEngine {
+            print("switchToServerEngine")
+            //TODO: Core Data에 쌓인 이벤트 로그 서버에 보내기
+            currentEngine = serverEngine
+        }
     }
     
     func switchToBackupEngine() {
-        currentEngine = backupEngine
+        if currentEngine !== backupEngine {
+            print("switchToBackupEngine")
+            currentEngine = backupEngine
+        }
     }
     
 }
@@ -53,10 +59,8 @@ extension AnalyticsManager: ReachabilityObserverDelegate {
     
     func reachabilityChanged(_ isReachable: Bool) {
         if isReachable {
-            print("switchToServerEngine")
             switchToServerEngine()
         } else {
-            print("switchToBackupEngine")
             switchToBackupEngine()
         }
     }

--- a/iOS/MiniVibe/MiniVibe/Common/Event/ScreenEvent.swift
+++ b/iOS/MiniVibe/MiniVibe/Common/Event/ScreenEvent.swift
@@ -12,7 +12,12 @@ struct ScreenEvent: AnalyticsEvent {
     var metadata: [String: String]
     
     enum ScreenType: String {
-        case today, chart, search
+        case today, chart, search, library
+        case playlist, magazine
+        case thumbnailList
+        case djStationList
+        case searchBefore, searchAfter
+        case error
     }
     
     private init(name: String, metadata: [String: String] = [:]) {
@@ -22,6 +27,10 @@ struct ScreenEvent: AnalyticsEvent {
 
     static func screenViewed(_ type: ScreenType) -> ScreenEvent {
         return ScreenEvent(name: "\(type)Viewed")
+    }
+    
+    static func screenViewedWithSource(_ type: ScreenType, source: ScreenType) -> ScreenEvent {
+        return ScreenEvent(name: "\(type)Viewed", metadata: ["from": "\(source)"])
     }
     
     //재생 화면은 좀 더 신경 써야해서 따로 빼놨습니다.

--- a/iOS/MiniVibe/MiniVibe/Common/Network/MiniVibeType.swift
+++ b/iOS/MiniVibe/MiniVibe/Common/Network/MiniVibeType.swift
@@ -23,7 +23,7 @@ enum MiniVibeType {
         case .albums:
             return "albums"
         case .djStations:
-            return "dj-station"
+            return "dj-stations"
         case .favorites:
             return "playlists?filter=9"
         case .recommendations:

--- a/iOS/MiniVibe/MiniVibe/Common/Reachability/ReachabilityObserverDelegate.swift
+++ b/iOS/MiniVibe/MiniVibe/Common/Reachability/ReachabilityObserverDelegate.swift
@@ -1,0 +1,51 @@
+//
+//  ReachabilityObserverDelegate.swift
+//  MiniVibe
+//
+//  Created by 강병민 on 2020/12/07.
+// https://gist.github.com/popcornomnom/aa06d98f8d9834101a634f358e524660#file-reachabilityobserverdelegate-swift 참고
+
+import Foundation
+import Reachability
+
+//Reachability
+//declare this property where it won't go out of scope relative to your listener
+fileprivate var reachability: Reachability!
+
+protocol ReachabilityActionDelegate {
+    func reachabilityChanged(_ isReachable: Bool)
+}
+
+protocol ReachabilityObserverDelegate: class, ReachabilityActionDelegate {
+    func addReachabilityObserver() throws
+    func removeReachabilityObserver()
+}
+
+// Declaring default implementation of adding/removing observer
+extension ReachabilityObserverDelegate {
+    
+    /** Subscribe on reachability changing */
+    func addReachabilityObserver() throws {
+        reachability = try Reachability()
+        
+        reachability.whenReachable = { [weak self] reachability in
+            self?.reachabilityChanged(true)
+        }
+        
+        reachability.whenUnreachable = { [weak self] reachability in
+            self?.reachabilityChanged(false)
+        }
+        
+        try reachability.startNotifier()
+    }
+    
+    /** Unsubscribe */
+    func removeReachabilityObserver() {
+        reachability.stopNotifier()
+        reachability = nil
+    }
+    
+    func getConnection() -> Reachability.Connection {
+        return reachability.connection
+    }
+}

--- a/iOS/MiniVibe/MiniVibe/Models/DJStation.swift
+++ b/iOS/MiniVibe/MiniVibe/Models/DJStation.swift
@@ -7,8 +7,17 @@
 
 import Foundation
 
-struct DJStation: Identifiable {
+struct DJStation: Codable, Identifiable {
     let id: Int
-    let imageName: String
-    let title: String = "TEMP"
+    let stationName: String
+    let cover: String
+    let popularity: Int
+}
+
+struct DJStationResponse: Codable {
+    let djStations: [DJStation]
+
+    enum CodingKeys: String, CodingKey {
+        case djStations = "DJStations"
+    }
 }

--- a/iOS/MiniVibe/MiniVibe/Scenes/Chart/ChartView.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/Chart/ChartView.swift
@@ -23,7 +23,7 @@ struct ChartView: View {
             ScrollView {
                 LazyVGrid(columns: layout) {
                     if let tracks = viewModel.playlist?.tracks {
-                        TrackHorizontalListView(tracks: tracks)
+                        TrackHorizontalListView(tracks: tracks, manager: manager)
                     }
                 }
             }

--- a/iOS/MiniVibe/MiniVibe/Scenes/DJStation/DJStationListView.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/DJStation/DJStationListView.swift
@@ -22,9 +22,8 @@ struct DJStationListView: View {
                 ForEach(stationViewModel.stations) { station in
                     Button(action: {
                     }, label: {
-                        Image(station.imageName)
-                            .resizable()
-                            .aspectRatio(contentMode: .fill)
+                        URLImage(urlString: station.cover)
+                            .frame(minHeight: 100)
                     })
                     .padding(.all, 15)
                     .accentColor(.green)

--- a/iOS/MiniVibe/MiniVibe/Scenes/DJStation/DJStationListViewModel.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/DJStation/DJStationListViewModel.swift
@@ -4,20 +4,19 @@
 //
 //  Created by 강병민 on 2020/11/26.
 //
+import Foundation
 import Combine
 
-class DJStationListViewModel: ObservableObject {
+class DJStationListViewModel: MiniVibeViewModel, ObservableObject {
     @Published var stations = [DJStation]()
     
     func fetchStations() {
-        stations = [.init(id: 1, imageName: "dj1"),
-                    .init(id: 2, imageName: "dj2"),
-                    .init(id: 3, imageName: "dj3"),
-                    .init(id: 4, imageName: "dj4"),
-                    .init(id: 5, imageName: "dj5"),
-                    .init(id: 6, imageName: "dj6"),
-                    .init(id: 7, imageName: "dj7"),
-                    .init(id: 8, imageName: "dj8")
-        ]
+        internalFetch(endPoint: .djStations) { [weak self] data in
+            if let decodedData = try? JSONDecoder().decode(DJStationResponse.self, from: data) {
+                DispatchQueue.main.async {
+                    self?.stations = decodedData.djStations
+                }
+            }
+        }
     }
 }

--- a/iOS/MiniVibe/MiniVibe/Scenes/Search/SearchView.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/Search/SearchView.swift
@@ -9,12 +9,13 @@ import SwiftUI
 import Combine
 
 struct SearchView: View {
-    @StateObject private var viewModel = SearchViewModel()
+    @ObservedObject private var viewModel: SearchViewModel
     private let manager: AnalyticsManager
     private let layout = [GridItem(.flexible())]
     
     init(manager: AnalyticsManager) {
         self.manager = manager
+        self.viewModel = SearchViewModel(manager: manager)
     }
 
     var body: some View {
@@ -40,9 +41,6 @@ struct SearchView: View {
             .navigationTitle("검색")
         }
         .padding()
-        .onAppear {
-            manager.log(ScreenEvent.screenViewed(.search))
-        }
     }
 }
 

--- a/iOS/MiniVibe/MiniVibe/Scenes/Search/SubViews/SearchBarView.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/Search/SubViews/SearchBarView.swift
@@ -37,7 +37,7 @@ struct SearchBarView: View {
             
             if viewModel.isEditing {
                 Button(action: {
-                    viewModel.reset()
+                    viewModel.searchText = ""
                     UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
 
                 }, label: {

--- a/iOS/MiniVibe/MiniVibe/Scenes/Thumbnail/ThumbnailListView.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/Thumbnail/ThumbnailListView.swift
@@ -46,7 +46,7 @@ struct ThumbnailListView: View {
 struct PlaylistListView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {
-            ThumbnailListView(router: ThumbnailRouter(routingStarter: .recommendations))
+            ThumbnailListView(router: ThumbnailRouter(routingStarter: .recommendations, manager: AnalyticsManager(engine: MockAnalyticsEngine())))
                 .preferredColorScheme(.dark)
         }
     }

--- a/iOS/MiniVibe/MiniVibe/Scenes/Thumbnail/ThumbnailRouter.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/Thumbnail/ThumbnailRouter.swift
@@ -11,21 +11,35 @@ class ThumbnailRouter: StarterOrientedRouterProtocol {
     typealias RoutingStarter = MiniVibeType
     
     let routingStarter: RoutingStarter
-    
-    init(routingStarter: RoutingStarter) {
+    private let manager: AnalyticsManager
+
+    init(routingStarter: RoutingStarter, manager: AnalyticsManager) {
         self.routingStarter = routingStarter
+        self.manager = manager
     }
     
     func getDestination(id: Int) -> AnyView {
         switch routingStarter {
         case .magazines:
-            return AnyView(MagazineView(magazineID: id))
+            return AnyView(MagazineView(magazineID: id)
+                            .onAppear{
+                                self.manager.log(ScreenEvent.screenViewedWithSource(.magazine, source: .thumbnailList))
+                            })
         case .recommendations:
-            return AnyView(PlaylistView(playlistID: id))
+            return AnyView(PlaylistView(playlistID: id)
+                            .onAppear {
+                                self.manager.log(ScreenEvent.screenViewedWithSource(.playlist, source: .thumbnailList))
+                            })
         case .favorites:
-            return AnyView(PlaylistView(playlistID: id))
+            return AnyView(PlaylistView(playlistID: id)
+                            .onAppear {
+                                self.manager.log(ScreenEvent.screenViewedWithSource(.playlist, source: .thumbnailList))
+                            })
         default:
-            return AnyView(ErrorView())
+            return AnyView(ErrorView()
+                            .onAppear {
+                                self.manager.log(ScreenEvent.screenViewedWithSource(.error, source: .thumbnailList))
+                            })
         }
     }
     

--- a/iOS/MiniVibe/MiniVibe/Scenes/Today/SubViews/Category.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/Today/SubViews/Category.swift
@@ -40,3 +40,14 @@ extension Category {
         }
     }
 }
+
+extension Category {
+    init(stations: [DJStation]) {
+        self.title = "DJ 스테이션"
+        self.type = .djStations
+        self.mode = .half
+        self.items = stations.map { station -> CategoryItem in
+            CategoryItem(station: station)
+        }
+    }
+}

--- a/iOS/MiniVibe/MiniVibe/Scenes/Today/SubViews/CategoryItem.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/Today/SubViews/CategoryItem.swift
@@ -41,5 +41,11 @@ extension CategoryItem {
 }
 
 extension CategoryItem {
-    //init이 필요할때는
+    init(station: DJStation) {
+        self.id = station.id
+        self.imageName = station.cover
+        self.title = nil
+        self.author = nil
+        self.description = nil
+    }
 }

--- a/iOS/MiniVibe/MiniVibe/Scenes/Today/SubViews/CategoryRouter.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/Today/SubViews/CategoryRouter.swift
@@ -10,16 +10,31 @@ import SwiftUI
 class CategoryRouter: DestinationOrientedRouterProtocol {
     
     typealias RoutingType = MiniVibeType
+    private let manager: AnalyticsManager
+    
+    init(manager: AnalyticsManager) {
+        self.manager = manager
+    }
+
     
     func getDestination(to routingDestination: MiniVibeType, with id: Int?) -> AnyView {
         guard let id = id else { return AnyView(ErrorView()) }
         switch routingDestination {
         case .magazines:
-            return AnyView(MagazineView(magazineID: id))
+            return AnyView(MagazineView(magazineID: id)
+                            .onAppear {
+                                self.manager.log(ScreenEvent.screenViewedWithSource(.magazine, source: .today))
+                            })
         case .favorites:
-            return AnyView(PlaylistView(playlistID: id))
+            return AnyView(PlaylistView(playlistID: id)
+                            .onAppear {
+                                self.manager.log(ScreenEvent.screenViewedWithSource(.playlist, source: .today))
+                            })
         case .recommendations:
-            return AnyView(PlaylistView(playlistID: id))
+            return AnyView(PlaylistView(playlistID: id)
+                            .onAppear {
+                                self.manager.log(ScreenEvent.screenViewedWithSource(.playlist, source: .today))
+                            })
         default:
             return AnyView(Text("기본 화면"))
         }

--- a/iOS/MiniVibe/MiniVibe/Scenes/Today/SubViews/CategoryView.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/Today/SubViews/CategoryView.swift
@@ -17,10 +17,18 @@ struct CategoryView: View {
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(alignment: .top) {
                     ForEach(category.items) { item in
-                        MemorySafeNavigationLink(
-                            contentView: CategoryCellView(item: item, mode: category.mode),
-                            destination: router.getDestination(to: category.type, with: item.id)
-                        )
+                        if category.type == MiniVibeType.djStations {
+                            Button(action: {
+                                
+                            }, label: {
+                                CategoryCellView(item: item, mode: category.mode)
+                            })
+                        } else {
+                            MemorySafeNavigationLink(
+                                contentView: CategoryCellView(item: item, mode: category.mode),
+                                destination: router.getDestination(to: category.type, with: item.id)
+                            )
+                        }
                     }
                 }
             }
@@ -36,13 +44,13 @@ struct CategoryRowView_Previews: PreviewProvider {
          .init(id: 2, imageName: "favorite1", title: "잠못드는 밤", author: "VIBE", description: nil),
          .init(id: 1, imageName: "favorite1", title: "잠못드는 밤", author: "VIBE", description: nil)
         ]
-
+    
     static var previews: some View {
         NavigationView {
             CategoryView(category: Category(title: "Station",
                                             items: favoritePlaylistItems,
                                             type: .magazines, mode: .full))
         }
-//        .preferredColorScheme(.dark)
+        //        .preferredColorScheme(.dark)
     }
 }

--- a/iOS/MiniVibe/MiniVibe/Scenes/Today/SubViews/CategoryView.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/Today/SubViews/CategoryView.swift
@@ -9,7 +9,12 @@ import SwiftUI
 
 struct CategoryView: View {
     let category: Category
-    private let router = CategoryRouter()
+    private let router: CategoryRouter
+    
+    init(category: Category, manager: AnalyticsManager) {
+        self.category = category
+        router = CategoryRouter(manager: manager)
+    }
     
     var body: some View {
         VStack(alignment: .leading) {
@@ -49,7 +54,7 @@ struct CategoryRowView_Previews: PreviewProvider {
         NavigationView {
             CategoryView(category: Category(title: "Station",
                                             items: favoritePlaylistItems,
-                                            type: .magazines, mode: .full))
+                                            type: .magazines, mode: .full), manager: AnalyticsManager(engine: MockAnalyticsEngine()))
         }
         //        .preferredColorScheme(.dark)
     }

--- a/iOS/MiniVibe/MiniVibe/Scenes/Today/TodayRouter.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/Today/TodayRouter.swift
@@ -10,6 +10,11 @@ import SwiftUI
 class TodayRouter: DestinationOrientedRouterProtocol {
     
     typealias RoutingStarter = MiniVibeType
+    private let manager: AnalyticsManager
+    
+    init(manager: AnalyticsManager) {
+        self.manager = manager
+    }
     
     func getDestination(to routingDestination: RoutingStarter, with id: Int? = nil) -> AnyView {
         switch routingDestination {

--- a/iOS/MiniVibe/MiniVibe/Scenes/Today/TodayRouter.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/Today/TodayRouter.swift
@@ -19,15 +19,35 @@ class TodayRouter: DestinationOrientedRouterProtocol {
     func getDestination(to routingDestination: RoutingStarter, with id: Int? = nil) -> AnyView {
         switch routingDestination {
         case .magazines:
-            return AnyView(ThumbnailListView(router: ThumbnailRouter(routingStarter: .magazines)))
+            return AnyView(ThumbnailListView(router: ThumbnailRouter(routingStarter: .magazines, manager: manager))
+                            .onAppear {
+                                self.manager.log(ScreenEvent.screenViewedWithSource(.thumbnailList, source: .today))
+                            }
+            )
         case .recommendations:
-            return AnyView(ThumbnailListView(router: ThumbnailRouter(routingStarter: .recommendations)))
+            return AnyView(ThumbnailListView(router: ThumbnailRouter(routingStarter: .recommendations, manager: manager))
+                            .onAppear {
+                                self.manager.log(ScreenEvent.screenViewedWithSource(.thumbnailList, source: .today))
+                            }
+            )
         case .favorites:
-            return AnyView(ThumbnailListView(router: ThumbnailRouter(routingStarter: .favorites)))
+            return AnyView(ThumbnailListView(router: ThumbnailRouter(routingStarter: .favorites, manager: manager))
+                            .onAppear {
+                                self.manager.log(ScreenEvent.screenViewedWithSource(.thumbnailList, source: .today))
+                            }
+            )
         case .djStations:
-            return AnyView(DJStationListView())
+            return AnyView(DJStationListView()
+                            .onAppear {
+                                self.manager.log(ScreenEvent.screenViewedWithSource(.djStationList, source: .today))
+                            }
+            )
         case .tracks:
-            return AnyView(PlaylistView(playlistID: 18))
+            return AnyView(PlaylistView(playlistID: 18)
+                            .onAppear {
+                                self.manager.log(ScreenEvent.screenViewedWithSource(.playlist, source: .today))
+                            }
+            )
         default:
             return AnyView(ErrorView())
         }

--- a/iOS/MiniVibe/MiniVibe/Scenes/Today/TodayView.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/Today/TodayView.swift
@@ -20,12 +20,12 @@ struct TodayView: View {
     var body: some View {
         NavigationView {
             List {
-                //                NavigationLink(
-                //                    destination: router.getDestination(to: .favorites),
-                //                    label: {
-                //                        CategoryView(category: category)
-                //                    }
-                //                )
+                let stationCategory = Category(stations: viewModel.stations)
+                MemorySafeNavigationLink(
+                    contentView: CategoryView(category: stationCategory),
+                    destination: router.getDestination(to: .djStations)
+                )
+
                 let favoritesCategory = Category(playlists: viewModel.favorites,
                                                  type: .favorites,
                                                  mode: .half)

--- a/iOS/MiniVibe/MiniVibe/Scenes/Today/TodayView.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/Today/TodayView.swift
@@ -22,7 +22,7 @@ struct TodayView: View {
             List {
                 let stationCategory = Category(stations: viewModel.stations)
                 MemorySafeNavigationLink(
-                    contentView: CategoryView(category: stationCategory),
+                    contentView: CategoryView(category: stationCategory, manager: manager),
                     destination: router.getDestination(to: .djStations)
                 )
 
@@ -30,14 +30,14 @@ struct TodayView: View {
                                                  type: .favorites,
                                                  mode: .half)
                 MemorySafeNavigationLink(
-                    contentView: CategoryView(category: favoritesCategory),
+                    contentView: CategoryView(category: favoritesCategory, manager: manager),
                     destination: router.getDestination(to: .favorites)
                 )
                 
                 let magazinesCategory = Category(magazines: viewModel.magazines,
                                                  mode: .full)
                 MemorySafeNavigationLink(
-                    contentView: CategoryView(category: magazinesCategory),
+                    contentView: CategoryView(category: magazinesCategory, manager: manager),
                     destination: router.getDestination(to: .magazines)
                 )
                 
@@ -45,7 +45,7 @@ struct TodayView: View {
                                                        type: .recommendations,
                                                        mode: .full)
                 MemorySafeNavigationLink(
-                    contentView: CategoryView(category: recommendationsCategory),
+                    contentView: CategoryView(category: recommendationsCategory, manager: manager),
                     destination: router.getDestination(to: .recommendations)
                 )
                 
@@ -66,6 +66,9 @@ struct TodayView: View {
             manager.log(ScreenEvent.screenViewed(.today))
             viewModel.fetchAll()
         })
+        .onDisappear {
+            
+        }
     }
 }
 

--- a/iOS/MiniVibe/MiniVibe/Scenes/Today/TodayView.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/Today/TodayView.swift
@@ -8,12 +8,13 @@
 import SwiftUI
 
 struct TodayView: View {
-    private let router = TodayRouter()
+    private let router: TodayRouter
     private let manager: AnalyticsManager
     @StateObject private var viewModel = TodayViewModel()
 
     init(manager: AnalyticsManager) {
         self.manager = manager
+        self.router = TodayRouter(manager: manager)
     }
 
     var body: some View {

--- a/iOS/MiniVibe/MiniVibe/Scenes/Today/TodayViewModel.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/Today/TodayViewModel.swift
@@ -15,10 +15,11 @@ class TodayViewModel: MiniVibeViewModel, ObservableObject {
     @Published var tracks = [Track]()
     
     func fetchAll() {
+        fetch(type: .djStations)
         fetch(type: .favorites)
         fetch(type: .magazines)
         fetch(type: .recommendations)
-        fetch(type: .playlists, id: 18)
+//        fetch(type: .playlists, id: 18)
     }
     
     func fetch(type: MiniVibeType, id: Int? = nil) {
@@ -31,8 +32,11 @@ class TodayViewModel: MiniVibeViewModel, ObservableObject {
                     }
                 }
             case .djStations:
-//                self?.stations = [DJStation(id: 1, imageName: nil)]
-                break
+                if let decodedData = try? JSONDecoder().decode(DJStationResponse.self, from: data) {
+                    DispatchQueue.main.async {
+                        self?.stations = decodedData.djStations
+                    }
+                }
             case .playlists:
                 if let decodedData = try? JSONDecoder().decode(PlayListReponse.self, from: data) {
                     DispatchQueue.main.async {

--- a/iOS/MiniVibe/MiniVibe/Scenes/TrackList/SubViews/TrackHorizontalListView.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/TrackList/SubViews/TrackHorizontalListView.swift
@@ -16,13 +16,22 @@ struct TrackHorizontalListView: View {
         GridItem(.fixed(60)),
         GridItem(.fixed(60))
     ]
+    private let manager: AnalyticsManager
+
+    init(tracks: [Track], manager: AnalyticsManager) {
+        self.tracks = tracks
+        self.manager = manager
+    }
     
     var body: some View {
         Group {
             VStack {
                 MemorySafeNavigationLink(
                     contentView: CategoryHeaderView(title: "오늘 TOP 100").foregroundColor(.primary),
-                    destination: AnyView(PlaylistView(playlistID: 18))
+                    destination: AnyView(PlaylistView(playlistID: 18)
+                                            .onAppear {
+                                                manager.log(ScreenEvent.screenViewedWithSource(.playlist, source: .chart))
+                                            })
                 )
                 ScrollView(.horizontal, showsIndicators: false) {
                     LazyHGrid(rows: layout,
@@ -39,6 +48,6 @@ struct TrackHorizontalListView: View {
 
 struct TrackHorizontalListView_Previews: PreviewProvider {
     static var previews: some View {
-        TrackHorizontalListView(tracks: TestData.playlist.tracks!)
+        TrackHorizontalListView(tracks: TestData.playlist.tracks!, manager: AnalyticsManager(engine: MockAnalyticsEngine()))
     }
 }


### PR DESCRIPTION
> DB 작업이 완료된 DJ Station과 앱 전체에서 쓰이는 화면 인벤트를 추가했습니다.
### 화면(optional)
이미지 용량이커서 링크로 대체합니다
https://hackmd.io/kiO_57dIQzeuX7fOzVGpvw?view    

                    
### 학습 내용(optional)
어떤 기술써서 어떻게 했다. 에 대한 기술 설명

## 논의사항
앱 내에서 일어나는 화면 이동과 관련된 이벤트를 모두 로깅했습니다

- 기본적으로 현재화면에 대한 로깅으로 했고,
- 투데이 화면 내 매거진/ 플레이리스트 같은 경우에는 접근할수 있는 방법이 두가지라
- 어디서왔는지를 metadata에 넘겼습니다.
- 재생화면은 push와 pop의 개념이 더 중요한것 같아서 메소드를 따로 분리했습니다.


```swift
    static func screenViewed(_ type: ScreenType) -> ScreenEvent {
        return ScreenEvent(name: "\(type)Viewed")
    }
    
    static func screenViewedWithSource(_ type: ScreenType, source: ScreenType) -> ScreenEvent {
        return ScreenEvent(name: "\(type)Viewed", metadata: ["from": "\(source)"])
    }
    
    //재생 화면은 좀 더 신경 써야해서 따로 빼놨습니다.
    static let playerPushed = ScreenEvent(name: "playerPushed")

    static let playerPopped = ScreenEvent(name: "playerPopped")

```

지금생각해보니까 브랜치를 나눠서 PR도 나눠서 보냈어야 했는데... 정신차려보니 이렇게 되었네요 ㅋㅋㅋㅋ
커밋은 최대한 잘게 나눴습니당...