### PR TITLE
[BE] fix: search api 수정

### DIFF
--- a/backend/controllers/public/search/getAlbums.ts
+++ b/backend/controllers/public/search/getAlbums.ts
@@ -1,0 +1,17 @@
+import { Request, Response } from "express";
+import { makeSearchOption } from "../../../utils/makePrismaObtion";
+import { getAlbumCovers } from "../../../models/albums";
+
+const getAlbums = async (req: Request, res: Response): Promise<void> => {
+  const albumFilter = makeSearchOption(req.query, "albumName");
+
+  try {
+    const result = await getAlbumCovers(albumFilter);
+
+    res.status(200).json(result);
+  } catch (err) {
+    res.status(500).json({ statusCode: 500, message: err.message });
+  }
+};
+
+export default getAlbums;

--- a/backend/controllers/public/search/getAll.ts
+++ b/backend/controllers/public/search/getAll.ts
@@ -1,0 +1,26 @@
+import { Request, Response } from "express";
+import { makeSearchOption } from "../../../utils/makePrismaObtion";
+import { getAlbumCovers } from "../../../models/albums";
+import { getArtistCovers } from "../../../models/artists";
+import { getTrackForSearch } from "../../../models/tracks";
+
+const getAll = async (req: Request, res: Response): Promise<void> => {
+  const albumFilter = makeSearchOption(req.query, "albumName");
+  const trackFilter = makeSearchOption(req.query, "trackName");
+  const artistFilter = makeSearchOption(req.query, "artistName");
+
+  try {
+    const result: any = {};
+
+    // TODO : PROMISE ALL
+    result.Albums = await getAlbumCovers(albumFilter);
+    result.Tracks = await getTrackForSearch(trackFilter);
+    result.Artists = await getArtistCovers(artistFilter);
+
+    res.status(200).json(result);
+  } catch (err) {
+    res.status(500).json({ statusCode: 500, message: err.message });
+  }
+};
+
+export default getAll;

--- a/backend/controllers/public/search/getArtists.ts
+++ b/backend/controllers/public/search/getArtists.ts
@@ -1,0 +1,17 @@
+import { Request, Response } from "express";
+import { makeSearchOption } from "../../../utils/makePrismaObtion";
+import { getArtistCovers } from "../../../models/artists";
+
+const getArtists = async (req: Request, res: Response): Promise<void> => {
+  const artistFilter = makeSearchOption(req.query, "artistName");
+
+  try {
+    const result = await getArtistCovers(artistFilter);
+
+    res.status(200).json(result);
+  } catch (err) {
+    res.status(500).json({ statusCode: 500, message: err.message });
+  }
+};
+
+export default getArtists;

--- a/backend/controllers/public/search/getTracks.ts
+++ b/backend/controllers/public/search/getTracks.ts
@@ -1,0 +1,17 @@
+import { Request, Response } from "express";
+import { makeSearchOption } from "../../../utils/makePrismaObtion";
+import { getTrackForSearch } from "../../../models/tracks";
+
+const getTracks = async (req: Request, res: Response): Promise<void> => {
+  const trackFilter = makeSearchOption(req.query, "trackName");
+
+  try {
+    const result = await getTrackForSearch(trackFilter);
+
+    res.status(200).json(result);
+  } catch (err) {
+    res.status(500).json({ statusCode: 500, message: err.message });
+  }
+};
+
+export default getTracks;

--- a/backend/controllers/public/search/index.ts
+++ b/backend/controllers/public/search/index.ts
@@ -1,31 +1,20 @@
 import { Request, Response } from "express";
-import { makeSearchOption } from "../../../utils/makePrismaObtion";
-import { getAlbumCovers } from "../../../models/albums";
-import { getArtistCovers } from "../../../models/artists";
-import { getTrackCovers } from "../../../models/tracks";
+import getAll from "./getAll";
+import getTracks from "./getAlbums";
+import getAlbums from "./getTracks";
+import getArtists from "./getArtists";
 
 interface Controller {
-  search(req: Request, res: Response): Promise<void>;
+  getAll(req: Request, res: Response): Promise<void>;
+  getTracks(req: Request, res: Response): Promise<void>;
+  getAlbums(req: Request, res: Response): Promise<void>;
+  getArtists(req: Request, res: Response): Promise<void>;
 }
 
-const search = async (req: Request, res: Response): Promise<void> => {
-  const albumFilter = makeSearchOption(req.query, "albumName");
-  const trackFilter = makeSearchOption(req.query, "trackName");
-  const artistFilter = makeSearchOption(req.query, "artistName");
-
-  try {
-    const result: any = {};
-
-    // TODO : PROMISE ALL
-    result.Albums = await getAlbumCovers(albumFilter);
-    result.Tracks = await getTrackCovers(trackFilter);
-    result.Artists = await getArtistCovers(artistFilter);
-
-    res.status(200).json(result);
-  } catch (err) {
-    res.status(500).json({ statusCode: 500, message: err.message });
-  }
+const controller: Controller = {
+  getAll,
+  getTracks,
+  getAlbums,
+  getArtists,
 };
-
-const controller: Controller = { search };
 export default controller;

--- a/backend/models/tracks/getTrackForSearch.ts
+++ b/backend/models/tracks/getTrackForSearch.ts
@@ -1,14 +1,15 @@
 import prisma from "../../prisma";
 
-const getTrackCovers = async (optObj: any): Promise<Object> => {
+const getTrackForSearch = async (optObj: any): Promise<Object> => {
   // eslint-disable-next-line no-param-reassign
   optObj.include = {
     Albums: {
       select: { cover: true },
     },
+    Artists_Tracks: true,
   };
   const result = await prisma.tracks.findMany(optObj);
   return result;
 };
 
-export default getTrackCovers;
+export default getTrackForSearch;

--- a/backend/models/tracks/index.ts
+++ b/backend/models/tracks/index.ts
@@ -1,4 +1,4 @@
 import getTrackCard from "./getTrackCard";
-import getTrackCovers from "./getCovers";
+import getTrackForSearch from "./getTrackForSearch";
 
-export { getTrackCard, getTrackCovers };
+export { getTrackCard, getTrackForSearch };

--- a/backend/routes/public/search/index.ts
+++ b/backend/routes/public/search/index.ts
@@ -2,6 +2,6 @@ import { Router } from "express";
 import searchController from "../../../controllers/public/search";
 
 const router = Router();
-router.get("/", searchController.search);
+router.get("/", searchController.getAll);
 
 export default router;

--- a/backend/routes/public/search/index.ts
+++ b/backend/routes/public/search/index.ts
@@ -3,5 +3,8 @@ import searchController from "../../../controllers/public/search";
 
 const router = Router();
 router.get("/", searchController.getAll);
+router.get("/tracks", searchController.getTracks);
+router.get("/artists", searchController.getArtists);
+router.get("/albums", searchController.getAlbums);
 
 export default router;

--- a/backend/utils/makePrismaObtion.ts
+++ b/backend/utils/makePrismaObtion.ts
@@ -1,6 +1,7 @@
 type optionObject = {
   take?: number;
   where?: Object;
+  skip?: number;
 };
 
 const makeOption = (_query: any, _target?: any, _type?: string): Object => {
@@ -26,7 +27,7 @@ const makeOption = (_query: any, _target?: any, _type?: string): Object => {
 };
 
 const makeSearchOption = (_query: any, _target: string): Object => {
-  const { limit, filter } = _query;
+  const { limit, filter, page } = _query;
   const optObj: optionObject = {};
 
   if (limit) {
@@ -36,6 +37,10 @@ const makeSearchOption = (_query: any, _target: string): Object => {
     optObj.where = {
       [_target]: { contains: filter },
     };
+  }
+  if (!limit && page) {
+    optObj.skip = (+page - 1) * 10;
+    optObj.take = 10;
   }
   return optObj;
 };


### PR DESCRIPTION
제목: [BE] fix: search api 수정

>한줄 요약
- search api에 pagination 기능 추가 

## 구현내용
- search api에 track에 artist 이름들이 가지 않아 수정(현재 M:N을 promis.all을 이용한 방법외에 방법이 보이지 않아 일단 보류)
- pagination 기능 추가
- track, album, artist 각각 검색 가능하도록 변경
