### PR TITLE
[FE] 매거진 메인페이지 작성

### DIFF
--- a/frontend/components/Card/index.style.ts
+++ b/frontend/components/Card/index.style.ts
@@ -17,6 +17,9 @@ const themes: any = {
   trackCardCover: `
     width: 2.5rem;
   `,
+  magazineBig: `
+    width: 19rem;
+  `,
 };
 
 export const StyledCard = styled.li<StyledCardProps>`

--- a/frontend/components/HoverImg/img.style.ts
+++ b/frontend/components/HoverImg/img.style.ts
@@ -21,6 +21,10 @@ const HoverImgthemes: any = {
     width: 2.5rem;
     height: 2.5rem;
   `,
+  magazineBig: `
+    width: 19rem;
+    height: 19rem;
+  `,
 };
 
 export const StyledHoverImg = styled.div<styledHoverImgProps>`

--- a/frontend/components/HoverImg/index.tsx
+++ b/frontend/components/HoverImg/index.tsx
@@ -14,6 +14,7 @@ export const getChildren = (hover: boolean, varient?: string): JSX.Element | nul
     case "todayBig":
     case "todaySmall":
     case "todayNews":
+    case "magazineBig":
       return <GeneralHoverCover hover={hover} />;
     case "trackCardCover":
       return <TrackCardHoverCover hover={hover} />;

--- a/frontend/components/Img/Img.style.ts
+++ b/frontend/components/Img/Img.style.ts
@@ -39,6 +39,10 @@ const themes: any = {
     width: 3rem;
     height: 3rem;
   `,
+  magazineBig: `
+    width: 19rem;
+    height: 19rem;
+  `,
 };
 
 const StyledImg = styled.img<styledImgProps>`

--- a/frontend/pages/magazines/index.tsx
+++ b/frontend/pages/magazines/index.tsx
@@ -10,6 +10,10 @@ import {
 } from "../../components/MagLabel";
 import { Magazine } from "../../interfaces";
 
+const MagazineContainer = styled.div`
+  width: 964px;
+`;
+
 const StyledPagetitle = styled.div`
   font-size: 2em;
   font-weight: bold;
@@ -46,11 +50,10 @@ const StyledHotMagOverlay = styled.div`
 const StyledSection = styled.div`
   width: 100%;
   display: grid;
-  grid-template-columns: repeat(3, minmax(50%, auto));
+  grid-template-columns: repeat(3, minmax(33%, auto));
   grid-template-rows: repeat(auto-fill, minmax(20%, auto));
   grid-auto-flow: row;
   row-gap: 1rem;
-  column-gap: 0.5rem;
   & + & {
     border-top: 1px solid rgba(0, 0, 0, 0.3);
   }
@@ -64,7 +67,7 @@ const IndexPage = memo(({ magazines }: any) => {
   };
 
   return (
-    <>
+    <MagazineContainer>
       <StyledPagetitle>VIBE MAG</StyledPagetitle>
       <StyledMagazineRadioContainer>
         <label htmlFor="magazineAll">
@@ -120,10 +123,10 @@ const IndexPage = memo(({ magazines }: any) => {
         {magazines
           .filter((value: Magazine) => magType === "ALL" || value.magazineType === magType)
           .map((value: Magazine) => (
-            <Card varient="todayBig" dataType="magazine" rawData={value} />
+            <Card varient="magazineBig" dataType="magazine" rawData={value} />
           ))}
       </StyledSection>
-    </>
+    </MagazineContainer>
   );
 });
 

--- a/frontend/pages/magazines/index.tsx
+++ b/frontend/pages/magazines/index.tsx
@@ -1,0 +1,152 @@
+import React, { ChangeEvent, memo, useState } from "react";
+import styled from "styled-components";
+import Card from "../../components/Card";
+import HotMagCard from "../../components/HotMagCard";
+import {
+  AllMagLabel,
+  GenreMagLabel,
+  PickMagLabel,
+  SpecialMagLabel,
+} from "../../components/MagLabel";
+import { Magazine } from "../../interfaces";
+
+const StyledPagetitle = styled.div`
+  font-size: 2em;
+  font-weight: bold;
+  margin: 2em 0em 1em 0em;
+`;
+
+const StyledMagazineRadioContainer = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: left;
+  & input {
+    display: none;
+  }
+`;
+
+const StyledHotMag = styled.div`
+  position: relative;
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  margin-top: 2.75em;
+  margin-bottom: 4.5em;
+`;
+
+const StyledHotMagOverlay = styled.div`
+  position: absolute;
+  background-color: #f2f2f2;
+  width: calc(100vw - 15em);
+  top: -4em;
+  z-index: 1;
+  height: 30em;
+`;
+
+const StyledSection = styled.div`
+  width: 100%;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(50%, auto));
+  grid-template-rows: repeat(auto-fill, minmax(20%, auto));
+  grid-auto-flow: row;
+  row-gap: 1rem;
+  column-gap: 0.5rem;
+  & + & {
+    border-top: 1px solid rgba(0, 0, 0, 0.3);
+  }
+`;
+
+const IndexPage = memo(({ magazines }: any) => {
+  const [magType, setMagType] = useState("ALL");
+
+  const handleTypeChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setMagType(e.target.value);
+  };
+
+  return (
+    <>
+      <StyledPagetitle>VIBE MAG</StyledPagetitle>
+      <StyledMagazineRadioContainer>
+        <label htmlFor="magazineAll">
+          <AllMagLabel />
+          <input
+            type="radio"
+            name="magazine-radio"
+            value="ALL"
+            id="magazineAll"
+            checked={magType === "ALL"}
+            onChange={handleTypeChange}
+          />
+        </label>
+        <label htmlFor="magazineSpecial">
+          <SpecialMagLabel />
+          <input
+            type="radio"
+            name="magazine-radio"
+            value="SPECIAL"
+            id="magazineSpecial"
+            checked={magType === "SPECIAL"}
+            onChange={handleTypeChange}
+          />
+        </label>
+        <label htmlFor="magazinePick">
+          <PickMagLabel />
+          <input
+            type="radio"
+            name="magazine-radio"
+            value="PICK"
+            id="magazinePick"
+            checked={magType === "PICK"}
+            onChange={handleTypeChange}
+          />
+        </label>
+        <label htmlFor="magazineGenre">
+          <GenreMagLabel />
+          <input
+            type="radio"
+            name="magazine-radio"
+            value="GENRE"
+            id="magazineGenre"
+            checked={magType === "GENRE"}
+            onChange={handleTypeChange}
+          />
+        </label>
+      </StyledMagazineRadioContainer>
+      <StyledHotMag>
+        <HotMagCard />
+        {/* <StyledHotMagOverlay /> */}
+      </StyledHotMag>
+      <StyledSection>
+        {magazines
+          .filter((value: Magazine) => magType === "ALL" || value.magazineType === magType)
+          .map((value: Magazine) => (
+            <Card varient="todayBig" dataType="magazine" rawData={value} />
+          ))}
+      </StyledSection>
+    </>
+  );
+});
+
+export default IndexPage;
+
+export async function getStaticProps() {
+  const apiUrl = process.env.API_URL;
+  const apiPort = process.env.API_PORT;
+
+  const VIBE_ID = 1;
+  const dataLength = 10;
+
+  try {
+    const res = await fetch(`${apiUrl}:${apiPort}/api/magazines?limit=${dataLength}`);
+    const magazines = await res.json();
+
+    return {
+      props: {
+        magazines: magazines.Magazines,
+      },
+    };
+  } catch (err) {
+    console.log(err);
+  }
+  return { props: {} };
+}


### PR DESCRIPTION
>매거진 메인페이지 작성 - css 디테일, 페이지네이팅은 미작성

## 구현내용
매거진 페이지 작성. 컴포넌트는 대부분 기존 컴포넌트 사용.
magType의 경우 state로 관리, radio버튼 변경시 onChange에서 state변경 -> state 따라 데이터 필터링
최소한의 css는 작성, 아주 디테일한 부분은 보완 필요
페이지네이션도 추가 필요
리팩토링 필요