### PR TITLE
[iOS] Memory Leak 해결, 애니메이션 수정, 화면 전환 버그 수정, UI Test 코드 추가

### DIFF
--- a/iOS/MiniVibe/MiniVibe/Scenes/Magazine/MagazineView.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/Magazine/MagazineView.swift
@@ -19,11 +19,14 @@ struct MagazineView: View {
     
     var body: some View {
         guard let magazine = viewModel.magazine,
-              let tracks = magazine.tracks else { return AnyView(EmptyView().onAppear(perform: {
-                viewModel.fetch(id: magazineID)
-            }))
-             
-        }
+              let tracks = magazine.tracks else {
+            return AnyView(EmptyView()
+                            .onAppear(perform: {
+                                withAnimation {
+                                    viewModel.fetch(id: magazineID)
+                                }
+                            })
+                            .navigationBarTitleDisplayMode(.inline))}
         
         return AnyView(
             ScrollView(showsIndicators: false) {

--- a/iOS/MiniVibe/MiniVibe/Scenes/NowPlaying/NowPlayingView.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/NowPlaying/NowPlayingView.swift
@@ -30,8 +30,8 @@ struct NowPlayingView: View {
             .accessibility(identifier: "NowPlayingView")
             HStack(spacing: 20) {
                 ToggleableImage(isEnabled: $viewModel.isPlaying,
-                                imageWhenTrue: "pause",
-                                imageWhenFalse: "play.fill",
+                                imageWhenTrue: "pause", colorWhenTrue: .gray,
+                                imageWhenFalse: "play.fill", colorWhenFalse: .gray,
                                 size: .medium)
                 Button(action: {
                     viewModel.playNextTrack()

--- a/iOS/MiniVibe/MiniVibe/Scenes/Player/PlayerViewModel.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/Player/PlayerViewModel.swift
@@ -18,6 +18,7 @@ class PlayerViewModel: ObservableObject {
     @Published var isPlaying = false
     @Published var isShuffle = false
     @Published var isRepeat = false
+    @Published var isFavorite = false
     private var isInitial = true
     @Published private var timeRemaining = 3
     
@@ -181,6 +182,7 @@ extension PlayerViewModel {
     private func trackPlayingSubscription() {
         $isPlaying
             .sink { [weak self] isPlaying in
+                self?.isFavorite = false
                 if let id = self?.currentTrack?.id {
                     if isPlaying {
                         self?.manager.log(PlayerEvent.trackPlayed(id))

--- a/iOS/MiniVibe/MiniVibe/Scenes/Player/SubViews/PlayerControlView.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/Player/SubViews/PlayerControlView.swift
@@ -9,14 +9,15 @@ import SwiftUI
 
 struct PlayerControlView: View {
     @ObservedObject var viewModel: PlayerViewModel
+    @State var isFavorite = false
     var didPressQueueButton: (() -> Void)?
     
     var body: some View {
         VStack {
             HStack {
                 ToggleableImage(isEnabled: $viewModel.isRepeat,
-                                imageWhenTrue: "repeat",
-                                imageWhenFalse: "repeat",
+                                imageWhenTrue: "repeat", colorWhenTrue: .red,
+                                imageWhenFalse: "repeat", colorWhenFalse: .gray,
                                 size: .medium)
                     .accessibility(identifier: "Repeat")
                 Spacer()
@@ -28,21 +29,22 @@ struct PlayerControlView: View {
                 .accentColor(.primary)
                 Spacer()
                 ToggleableImage(isEnabled: $viewModel.isPlaying,
-                                imageWhenTrue: "pause",
-                                imageWhenFalse: "play",
+                                imageWhenTrue: "pause", colorWhenTrue: .gray,
+                                imageWhenFalse: "play", colorWhenFalse: .gray,
                                 size: .large)
                     .accessibility(identifier: "PauseOrPlay")
                 .accentColor(.primary)
                 Spacer()
-                Button(action: {}, label: {
-                    Image(systemName: "heart")
-                        .accesoryModifier(color: .red, size: .large)
-                })
+                ToggleableImage(isEnabled: $viewModel.isFavorite,
+                                imageWhenTrue: "heart.fill", colorWhenTrue: .red,
+                                imageWhenFalse: "heart", colorWhenFalse: .red,
+                                size: .large)
+                    .accessibility(identifier: "Heart")
                 .accentColor(.red)
                 Spacer()
                 ToggleableImage(isEnabled: $viewModel.isShuffle,
-                                imageWhenTrue: "shuffle",
-                                imageWhenFalse: "shuffle",
+                                imageWhenTrue: "shuffle", colorWhenTrue: .red,
+                                imageWhenFalse: "shuffle", colorWhenFalse: .gray,
                                 size: .medium)
                     .accessibility(identifier: "Shuffle")
             }

--- a/iOS/MiniVibe/MiniVibe/Scenes/Player/SubViews/ToggleableImage.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/Player/SubViews/ToggleableImage.swift
@@ -10,7 +10,9 @@ import SwiftUI
 struct ToggleableImage: View {
     @Binding var isEnabled: Bool
     let imageWhenTrue: String
+    let colorWhenTrue: Color
     let imageWhenFalse: String
+    let colorWhenFalse: Color
     let size: Image.AccessorySize
     var eventHandler: (() -> Void)?
     
@@ -21,10 +23,10 @@ struct ToggleableImage: View {
         }, label: {
             if isEnabled {
                 Image(systemName: imageWhenTrue)
-                    .accesoryModifier(color: .red, size: size)
+                    .accesoryModifier(color: colorWhenTrue, size: size)
             } else {
                 Image(systemName: imageWhenFalse)
-                    .accesoryModifier(color: .gray, size: size)
+                    .accesoryModifier(color: colorWhenFalse, size: size)
 
             }
         })

--- a/iOS/MiniVibe/MiniVibe/Scenes/Playlist/PlaylistView.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/Playlist/PlaylistView.swift
@@ -19,10 +19,14 @@ struct PlaylistView: View {
     
     var body: some View {
         guard let playlist = viewModel.playlist,
-              let tracks = playlist.tracks else { return AnyView(EmptyView().onAppear(perform: {
-                viewModel.fetch(id: playlistID)
-            }))
-        }
+              let tracks = playlist.tracks else {
+            return AnyView(EmptyView()
+                            .onAppear(perform: {
+                                withAnimation {
+                                    viewModel.fetch(id: playlistID)
+                                }
+                            })
+                            .navigationBarTitleDisplayMode(.inline))}
         
         return AnyView(
             ScrollView(showsIndicators: false) {
@@ -36,18 +40,14 @@ struct PlaylistView: View {
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .principal) {
-                    VStack {
-                        if let name = playlist.name {
-                            Text(name)
-                                .modifier(Title2())
-                        }
-                        if let author = playlist.user?.name {
-                            Text(author)
-                                .modifier(Description2())
-                        }
+                    if let name = playlist.name {
+                        Text(name)
+                            .modifier(Title2())
+                            .transition(.slide)
                     }
                 }
             }
+            
         )
     }
 }

--- a/iOS/MiniVibe/MiniVibe/Scenes/Search/SearchView.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/Search/SearchView.swift
@@ -27,6 +27,7 @@ struct SearchView: View {
                     Section(header: SearchBarView(viewModel: viewModel)) {
                         if viewModel.isEditing {
                             SearchAfterView(viewModel: viewModel)
+                                .animation(.easeInOut)
                         } else {
                             SearchBeforeView()
                         }

--- a/iOS/MiniVibe/MiniVibe/Scenes/Search/SearchViewModel.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/Search/SearchViewModel.swift
@@ -64,8 +64,8 @@ class SearchViewModel: ObservableObject {
         $searchText
             .debounce(for: .milliseconds(500), scheduler: RunLoop.main)
             .removeDuplicates()
-            .map({ (string) -> String? in
-                self.validate(string)
+            .map({[weak self] (string) -> String? in
+                self?.validate(string)
             })
             .compactMap { $0 }
             .sink { (_) in
@@ -82,10 +82,6 @@ class SearchViewModel: ObservableObject {
                 if isEditing {
                     self?.manager.log(ScreenEvent.screenViewed(.searchAfter))
                 } else {
-                    UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder),
-                                                    to: nil,
-                                                    from: nil,
-                                                    for: nil)
                     self?.manager.log(ScreenEvent.screenViewed(.searchBefore))
                 }
             }
@@ -94,9 +90,6 @@ class SearchViewModel: ObservableObject {
 
     private func validate(_ string: String) -> String? {
         if string.isEmpty { 
-            if self.isEditing {
-                 self.reset()
-            }
             return nil
         }
         return string

--- a/iOS/MiniVibe/MiniVibe/Scenes/Search/SubViews/RectangleCellInfoView.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/Search/SubViews/RectangleCellInfoView.swift
@@ -13,20 +13,25 @@ struct RectangleCellInfoView: View {
             Rectangle()
                 .fill(Color.white)
             HStack {
-                Text("EXO 카이가 솔로 데뷔곡 MV를 선공개했습니다.")
+                Text("아이유, 타이틀곡 ‘Blueming’ 티저공개... 미니 5집으로 컴백")
                     .multilineTextAlignment(.leading)
                     .font(.system(size: 18, weight: .bold))
                     .foregroundColor(.black)
                     .lineLimit(2)
-                    .padding([.leading, .top])
+                    .padding([.horizontal, .top])
                 Spacer()
             }
             HStack {
                 Spacer()
-                Image(systemName: "play.circle")
-                Text("음악듣기")
+                Button(action: {
+                    //TODO: 이벤트 추가
+                }, label: {
+                    Image(systemName: "play.circle")
+                    Text("음악듣기")
+                })
+                .foregroundColor(Color.pink)
+
             }
-            .foregroundColor(Color.pink)
             .padding(.trailing)
             .padding(.top, 64)
         }

--- a/iOS/MiniVibe/MiniVibe/Scenes/Search/SubViews/SearchBarView.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/Search/SubViews/SearchBarView.swift
@@ -12,11 +12,10 @@ struct SearchBarView: View {
     
     var body: some View {
         HStack {
-            TextField("검색어를 입력해 주세요.", text: $viewModel.searchText) { isEditing in
-                viewModel.isEditing = isEditing
-            } onCommit: {
-                viewModel.reset()
-            }
+            TextField("검색어를 입력해주세요", text: $viewModel.searchText)
+                .onTapGesture {
+                    viewModel.isEditing = true
+                }
             .padding(9)
             .padding(.horizontal, 27)
             .background(Color(.systemGray6))
@@ -38,7 +37,10 @@ struct SearchBarView: View {
             if viewModel.isEditing {
                 Button(action: {
                     viewModel.reset()
-
+                    UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder),
+                                                    to: nil,
+                                                    from: nil,
+                                                    for: nil)
                 }, label: {
                     Text("취소")
                 })

--- a/iOS/MiniVibe/MiniVibe/Scenes/Search/SubViews/SearchBarView.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/Search/SubViews/SearchBarView.swift
@@ -12,31 +12,33 @@ struct SearchBarView: View {
     
     var body: some View {
         HStack {
-            TextField("검색어를 입력해주세요", text: $viewModel.searchText)
-                .onTapGesture {
-                    viewModel.isEditing = true
-                }
-            .padding(9)
-            .padding(.horizontal, 27)
-            .background(Color(.systemGray6))
-            .cornerRadius(8)
-            .overlay(
-                HStack {
-                    Image(systemName: "magnifyingglass")
-                        .foregroundColor(.gray)
-                        .frame(minWidth: 0, maxWidth: .infinity, alignment: .leading)
-                        .padding(.leading, 12)
-//                    if !viewModel.isEditing {
-//                        Image(systemName: "music.note")
-//                            .foregroundColor(.gray)
-//                            .padding(.trailing, 12)
-//                    }
-                }
-            )
+            TextField("검색어를 입력해주세요",
+                      text: $viewModel.searchText,
+                      onEditingChanged: { isEditing in
+                        withAnimation {
+                            viewModel.isEditing = isEditing
+                        }},
+                      onCommit: {
+                        viewModel.reset()
+                      })
+                .padding(9)
+                .padding(.horizontal, 27)
+                .background(Color(.systemGray6))
+                .cornerRadius(8)
+                .overlay(
+                    HStack {
+                        Image(systemName: "magnifyingglass")
+                            .foregroundColor(.gray)
+                            .frame(minWidth: 0, maxWidth: .infinity, alignment: .leading)
+                            .padding(.leading, 12)
+                    }
+                )
             
             if viewModel.isEditing {
                 Button(action: {
-                    viewModel.reset()
+                    withAnimation {
+                        viewModel.reset()
+                    }
                     UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder),
                                                     to: nil,
                                                     from: nil,
@@ -45,8 +47,6 @@ struct SearchBarView: View {
                     Text("취소")
                 })
                 .padding(.trailing, 10)
-                .animation(.default)
-                .transition(.move(edge: .trailing))
             }
         }
     }

--- a/iOS/MiniVibe/MiniVibe/Scenes/Search/SubViews/SearchBarView.swift
+++ b/iOS/MiniVibe/MiniVibe/Scenes/Search/SubViews/SearchBarView.swift
@@ -21,7 +21,7 @@ struct SearchBarView: View {
                       onCommit: {
                         viewModel.reset()
                       })
-                .padding(9)
+                .padding(15)
                 .padding(.horizontal, 27)
                 .background(Color(.systemGray6))
                 .cornerRadius(8)
@@ -33,6 +33,7 @@ struct SearchBarView: View {
                             .padding(.leading, 12)
                     }
                 )
+                .zIndex(2)
             
             if viewModel.isEditing {
                 Button(action: {
@@ -47,13 +48,14 @@ struct SearchBarView: View {
                     Text("취소")
                 })
                 .padding(.trailing, 10)
+                .zIndex(1)
             }
         }
     }
 }
-//
-//struct SearchBarView_Previews: PreviewProvider {
-//    static var previews: some View {
-//        SearchBarView(defaultText: "")
-//    }
-//}
+
+struct SearchBarView_Previews: PreviewProvider {
+    static var previews: some View {
+        SearchBarView(viewModel: SearchViewModel(manager: AnalyticsManager(serverEngine: nil, backupEngine: nil, alertEngine: nil)))
+    }
+}

--- a/iOS/MiniVibe/MiniVibeUITests/XCUIElement+Scroll.swift
+++ b/iOS/MiniVibe/MiniVibeUITests/XCUIElement+Scroll.swift
@@ -5,4 +5,17 @@
 //  Created by 강병민 on 2020/12/15.
 //
 
-import Foundation
+import XCTest
+
+extension XCUIElement {
+    func scrollToElement(element: XCUIElement) {
+        while !element.visible() {
+            swipeUp()
+        }
+    }
+
+    func visible() -> Bool {
+        guard self.exists && !self.frame.isEmpty else { return false }
+        return XCUIApplication().windows.element(boundBy: 0).frame.contains(self.frame)
+    }
+}

--- a/iOS/MiniVibe/MiniVibeUITests/XCUIElement+Scroll.swift
+++ b/iOS/MiniVibe/MiniVibeUITests/XCUIElement+Scroll.swift
@@ -1,0 +1,8 @@
+//
+//  XCUIElement+Scroll.swift
+//  MiniVibeUITests
+//
+//  Created by 강병민 on 2020/12/15.
+//
+
+import Foundation


### PR DESCRIPTION

## 구현내용
검색화면에서 memory leak이 나는 부분을 수정했습니다
검색화면 검색 전/후 일어나는 애니메이션을 수정했습니다
검색화면의 search bar와 뉴스 view를 수정했습니다
Today에서 플레이리스트/매거진 화면으로 옮길시 나타는 화면 glitch 현상 수정했습니다.
Today 화면 UI test 코드 또한 추가했습니다.

## 화면 
![image](https://user-images.githubusercontent.com/64558078/102106951-85643f00-3e74-11eb-88e9-6dbe3aa1bad4.png)

