### PR TITLE
[FE] fix: playqueue delete 로직 수정

### DIFF
--- a/frontend/components/Layout/Overlay.tsx
+++ b/frontend/components/Layout/Overlay.tsx
@@ -22,7 +22,7 @@ import {
 import icons from "../../constant/icons";
 import Img from "../Img";
 
-const TrackCard = ({ track }: { track: Track }): React.ReactElement => {
+const TrackCard = ({ track, idx }: { track: Track; idx: number }): React.ReactElement => {
   const dispatch = useDispatch();
 
   const {
@@ -35,7 +35,7 @@ const TrackCard = ({ track }: { track: Track }): React.ReactElement => {
   Artists.forEach((el) => artists.push(el.artistName));
 
   const handleRemove = () => {
-    dispatch(removePlayQueue(track));
+    dispatch(removePlayQueue(idx));
   };
 
   return (
@@ -85,8 +85,8 @@ const Overlay = (): React.ReactElement => {
           </StyledButtons>
         </StyledOverlayControl>
         <StyledTrackLists>
-          {playList.map((track) => (
-            <TrackCard key={track.id} track={track} />
+          {playList.map((track, idx) => (
+            <TrackCard key={-idx} track={track} idx={idx} />
           ))}
         </StyledTrackLists>
       </StyledOverlayBar>

--- a/frontend/reduxModules/playQueue/index.ts
+++ b/frontend/reduxModules/playQueue/index.ts
@@ -16,7 +16,7 @@ interface ConcatenateAction {
 
 interface RemoveAction {
   type: typeof REMOVE;
-  payload: Track;
+  payload: number;
 }
 
 export type PlayQueueActionTypes = InitAction | ConcatenateAction | RemoveAction;
@@ -35,10 +35,10 @@ export const concatenatePlayQueue = (tracks: Set<Track>): ConcatenateAction => {
   };
 };
 
-export const removePlayQueue = (track: Track): RemoveAction => {
+export const removePlayQueue = (idx: number): RemoveAction => {
   return {
     type: REMOVE,
-    payload: track,
+    payload: idx,
   };
 };
 
@@ -54,7 +54,7 @@ const playQueueReducer = (state = initialState, action: PlayQueueActionTypes): T
       return state.concat([...action.payload]);
 
     case REMOVE:
-      return state.filter((track) => track.id !== action.payload.id);
+      return state.filter((track, idx) => idx !== action.payload);
 
     default:
       return state;


### PR DESCRIPTION
제목: [FE] fix: playqueue delete 로직 수정

>한줄 요약
playqueue delete 로직 수정

## 구현내용
- 원래 같은 id를 삭제하는 로직을 index를 기준으로 삭제하도록 수정
